### PR TITLE
Updated config to support core

### DIFF
--- a/fhir/src/config.js
+++ b/fhir/src/config.js
@@ -1,3 +1,4 @@
+const { VERSIONS } = require('@asymmetrik/node-fhir-server-core/src/constants');
 const path = require('path');
 const env = require('var');
 
@@ -56,16 +57,13 @@ let fhirServerConfig = {
 		// optional - registration
 	],
 	profiles: {
-		dstu2: {
-			patient: {
-				service: path.resolve('./src/services/patient/patient.service.js')
-			},
-			observation: {
-				service: path.resolve('./src/services/observation/observation.service.js')
-			},
-			oauth: {
-				service: path.resolve('./src/services/oauth/oauth.service.js')
-			}
+		patient: {
+			service: path.resolve('./src/services/patient/patient.service.js'),
+			versions: [ VERSIONS.STU3 ]
+		},
+		observation: {
+			service: path.resolve('./src/services/observation/observation.service.js'),
+			versions: [ VERSIONS.STU3 ]
 		}
 	}
 };


### PR DESCRIPTION
This is blocked by [https://github.com/Asymmetrik/node-fhir-server-core/pull/32](https://github.com/Asymmetrik/node-fhir-server-core/pull/32).

This makes the basic updates to function with the new core. OAuth is currently disabled as it is not yet supported in the new core.