### PR TITLE
Support CUD operations (R already supported)

### DIFF
--- a/fhir/package.json
+++ b/fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-mongo",
-  "version": "1.0.2",
+  "version": "1.0.4-rc1",
   "description": "Mongo Server implementing @asymmetrik/node-fhir-server-core",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/node-fhir-server-mongo.git",

--- a/fhir/package.json
+++ b/fhir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-mongo",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Mongo Server implementing @asymmetrik/node-fhir-server-core",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/node-fhir-server-mongo.git",
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@asymmetrik/node-fhir-server-core": "git+https://github.com/Asymmetrik/node-fhir-server-core.git#develop",
+    "@asymmetrik/node-fhir-server-core": "git+https://github.com/Asymmetrik/node-fhir-server-core.git#hotfix/writing",
     "jsonwebtoken": "^8.1.0",
     "moment-timezone": "^0.5.14",
     "mongodb": "^3.0.1",

--- a/fhir/src/services/observation/observation.service.js
+++ b/fhir/src/services/observation/observation.service.js
@@ -109,11 +109,9 @@ module.exports.createObservation = (args, logger) => new Promise((resolve, rejec
 	let db = globals.get(CLIENT_DB);
 	let collection = db.collection(COLLECTION.OBSERVATION);
 	// If there is an id, use it, otherwise let mongo generate it
-	if (id) {
-		resource._id = id;
-	}
+	let doc = Object.assign(resource.toJSON(), { _id: id });
 	// Insert our observation record
-	collection.insert(resource.toJSON(), (err, res) => {
+	collection.insert(doc, (err, res) => {
 		if (err) {
 			logger.error('Error with Observation.createObservation: ', err);
 			return reject(err);
@@ -141,14 +139,14 @@ module.exports.updateObservation = (args, logger) => new Promise((resolve, rejec
 	// Set the id of the resource
 	let doc = Object.assign(resource.toJSON(), { _id: id });
 	// Insert/update our observation record
-	collection.findOneAndUpdate({ _id: id }, doc, { upsert: true }, (err, res) => {
+	collection.findOneAndUpdate({ id: id }, doc, { upsert: true }, (err, res) => {
 		if (err) {
 			logger.error('Error with Observation.updateObservation: ', err);
 			return reject(err);
 		}
 		// If we support versioning, which we do not at the moment,
 		// we need to return a version
-		return resolve({ id: res.value && res.value._id });
+		return resolve({ id: res.value && res.value.id });
 	});
 });
 
@@ -166,7 +164,7 @@ module.exports.deleteObservation = (args, logger) => new Promise((resolve, rejec
 	let db = globals.get(CLIENT_DB);
 	let collection = db.collection(COLLECTION.OBSERVATION);
 	// Delete our observation record
-	collection.remove({ _id: id }, (err, _) => {
+	collection.remove({ id: id }, (err, _) => {
 		if (err) {
 			logger.error('Error with Observation.deleteObservation');
 			return reject({

--- a/fhir/src/services/patient/patient.service.js
+++ b/fhir/src/services/patient/patient.service.js
@@ -154,7 +154,7 @@ module.exports.updatePatient = (args, logger) => new Promise((resolve, reject) =
 		}
 		// If we support versioning, which we do not at the moment,
 		// we need to return a version
-		return resolve({ id: res.value && res.value._id });
+		return resolve({ id: res.value && res.value.id });
 	});
 });
 

--- a/fhir/src/services/patient/patient.service.js
+++ b/fhir/src/services/patient/patient.service.js
@@ -147,7 +147,7 @@ module.exports.updatePatient = (args, logger) => new Promise((resolve, reject) =
 	// Set the id of the resource
 	let doc = Object.assign(resource.toJSON(), { _id: id });
 	// Insert/update our patient record
-	collection.findOneAndUpdate({ _id: id }, doc, { upsert: true }, (err, res) => {
+	collection.findOneAndUpdate({ id: id }, doc, { upsert: true }, (err, res) => {
 		if (err) {
 			logger.error('Error with Patient.updatePatient: ', err);
 			return reject(err);
@@ -172,7 +172,7 @@ module.exports.deletePatient = (args, logger) => new Promise((resolve, reject) =
 	let db = globals.get(CLIENT_DB);
 	let collection = db.collection(COLLECTION.PATIENT);
 	// Delete our patient record
-	collection.remove({ _id: id }, (err, _) => {
+	collection.remove({ id: id }, (err, _) => {
 		if (err) {
 			logger.error('Error with Patient.deletePatient');
 			return reject({


### PR DESCRIPTION
Add support for create, update, and delete operations for patient's and observation's.

**What's here**

* Added create, update, and delete functions to patient and observation services
* Added patient test file

**TODO's before merging**

* Currently pointing to `node-fhir-server-core#hotfix/writing`. When that branch is merged this needs to point to develop.
* `patient.service.test.js` is empty, I need to add some tests so the workflow test's all CRUD operations.
* Update the current observation tests to test all CRUD operations