### PR TITLE
Fix issue of ObjectID not being generated on the server for create

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asymmetrik/node-fhir-server-mongo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "FHIR Facade Server implementing @asymmetrik/node-fhir-server-core",
   "main": "src/index.js",
   "repository": "https://github.com/Asymmetrik/node-fhir-server-mongo.git",

--- a/src/config.js
+++ b/src/config.js
@@ -90,10 +90,10 @@ let fhirServerConfig = {
 			service: './src/services/patient/patient.service.js',
 			versions: [ VERSIONS['3_0_1'], VERSIONS['1_0_2'] ]
 		},
-		[RESOURCES.ACCOUNT]: {
-			service: './src/services/account/account.service.js',
-			versions: [ VERSIONS['3_0_1'] ]
-		},
+		// [RESOURCES.ACCOUNT]: {
+		// 	service: './src/services/account/account.service.js',
+		// 	versions: [ VERSIONS['3_0_1'] ]
+		// },
 		// [RESOURCES.ACTIVITYDEFINITION]: {
 		// 	service: './src/services/activitydefinition/activitydefinition.service.js',
 		// 	versions: [ VERSIONS['3_0_1'] ]

--- a/src/config.js
+++ b/src/config.js
@@ -90,10 +90,10 @@ let fhirServerConfig = {
 			service: './src/services/patient/patient.service.js',
 			versions: [ VERSIONS['3_0_1'], VERSIONS['1_0_2'] ]
 		},
-		// [RESOURCES.ACCOUNT]: {
-		// 	service: './src/services/account/account.service.js',
-		// 	versions: [ VERSIONS['3_0_1'] ]
-		// },
+		[RESOURCES.ACCOUNT]: {
+			service: './src/services/account/account.service.js',
+			versions: [ VERSIONS['3_0_1'] ]
+		},
 		// [RESOURCES.ACTIVITYDEFINITION]: {
 		// 	service: './src/services/activitydefinition/activitydefinition.service.js',
 		// 	versions: [ VERSIONS['3_0_1'] ]

--- a/src/services/account/account.service.js
+++ b/src/services/account/account.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAccount = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ACCOUNT));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Account >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Account = getAccount(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: account_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([account_resource]);
 });
-

--- a/src/services/activitydefinition/activitydefinition.service.js
+++ b/src/services/activitydefinition/activitydefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getActivityDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ACTIVITYDEFINITION));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ActivityDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ActivityDefinition = getActivityDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: activitydefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([activitydefinition_resource]);
 });
-

--- a/src/services/adverseevent/adverseevent.service.js
+++ b/src/services/adverseevent/adverseevent.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAdverseEvent = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ADVERSEEVENT));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('AdverseEvent >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let AdverseEvent = getAdverseEvent(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: adverseevent_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([adverseevent_resource]);
 });
-

--- a/src/services/allergyintolerance/allergyintolerance.service.js
+++ b/src/services/allergyintolerance/allergyintolerance.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAllergyIntolerance = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ALLERGYINTOLERANCE));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('AllergyIntolerance >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let AllergyIntolerance = getAllergyIntolerance(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: allergyintolerance_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([allergyintolerance_resource]);
 });
-

--- a/src/services/appointment/appointment.service.js
+++ b/src/services/appointment/appointment.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAppointment = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.APPOINTMENT));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Appointment >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Appointment = getAppointment(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: appointment_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([appointment_resource]);
 });
-

--- a/src/services/appointmentresponse/appointmentresponse.service.js
+++ b/src/services/appointmentresponse/appointmentresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAppointmentResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.APPOINTMENTRESPONSE));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('AppointmentResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let AppointmentResponse = getAppointmentResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: appointmentresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([appointmentresponse_resource]);
 });
-

--- a/src/services/auditevent/auditevent.service.js
+++ b/src/services/auditevent/auditevent.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getAuditEvent = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.AUDITEVENT));};
@@ -79,7 +80,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('AuditEvent >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let AuditEvent = getAuditEvent(base_version);
 	let Meta = getMeta(base_version);
@@ -94,7 +97,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: auditevent_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -232,4 +235,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([auditevent_resource]);
 });
-

--- a/src/services/basic/basic.service.js
+++ b/src/services/basic/basic.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getBasic = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.BASIC));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Basic >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Basic = getBasic(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: basic_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([basic_resource]);
 });
-

--- a/src/services/binary/binary.service.js
+++ b/src/services/binary/binary.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getBinary = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.BINARY));};
@@ -60,7 +61,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Binary >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Binary = getBinary(base_version);
 	let Meta = getMeta(base_version);
@@ -75,7 +78,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: binary_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -175,4 +178,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([binary_resource]);
 });
-

--- a/src/services/bodysite/bodysite.service.js
+++ b/src/services/bodysite/bodysite.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getBodySite = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.BODYSITE));};
@@ -62,7 +63,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('BodySite >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let BodySite = getBodySite(base_version);
 	let Meta = getMeta(base_version);
@@ -77,7 +80,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: bodysite_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -181,4 +184,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([bodysite_resource]);
 });
-

--- a/src/services/bundle/bundle.service.js
+++ b/src/services/bundle/bundle.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getBundle = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.BUNDLE));};
@@ -63,7 +64,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Bundle >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Bundle = getBundle(base_version);
 	let Meta = getMeta(base_version);
@@ -78,7 +81,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: bundle_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -184,4 +187,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([bundle_resource]);
 });
-

--- a/src/services/capabilitystatement/capabilitystatement.service.js
+++ b/src/services/capabilitystatement/capabilitystatement.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCapabilityStatement = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CAPABILITYSTATEMENT));};
@@ -78,7 +79,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CapabilityStatement >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CapabilityStatement = getCapabilityStatement(base_version);
 	let Meta = getMeta(base_version);
@@ -93,7 +96,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: capabilitystatement_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -229,4 +232,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([capabilitystatement_resource]);
 });
-

--- a/src/services/careplan/careplan.service.js
+++ b/src/services/careplan/careplan.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCarePlan = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CAREPLAN));};
@@ -79,7 +80,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CarePlan >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CarePlan = getCarePlan(base_version);
 	let Meta = getMeta(base_version);
@@ -94,7 +97,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: careplan_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -232,4 +235,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([careplan_resource]);
 });
-

--- a/src/services/careteam/careteam.service.js
+++ b/src/services/careteam/careteam.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCareTeam = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CARETEAM));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CareTeam >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CareTeam = getCareTeam(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: careteam_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([careteam_resource]);
 });
-

--- a/src/services/chargeitem/chargeitem.service.js
+++ b/src/services/chargeitem/chargeitem.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getChargeItem = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CHARGEITEM));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ChargeItem >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ChargeItem = getChargeItem(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: chargeitem_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([chargeitem_resource]);
 });
-

--- a/src/services/claim/claim.service.js
+++ b/src/services/claim/claim.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getClaim = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CLAIM));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Claim >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Claim = getClaim(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: claim_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([claim_resource]);
 });
-

--- a/src/services/claimresponse/claimresponse.service.js
+++ b/src/services/claimresponse/claimresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getClaimResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CLAIMRESPONSE));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ClaimResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ClaimResponse = getClaimResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: claimresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([claimresponse_resource]);
 });
-

--- a/src/services/clinicalimpression/clinicalimpression.service.js
+++ b/src/services/clinicalimpression/clinicalimpression.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getClinicalImpression = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CLINICALIMPRESSION));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ClinicalImpression >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ClinicalImpression = getClinicalImpression(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: clinicalimpression_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([clinicalimpression_resource]);
 });
-

--- a/src/services/codesystem/codesystem.service.js
+++ b/src/services/codesystem/codesystem.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCodeSystem = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CODESYSTEM));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CodeSystem >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CodeSystem = getCodeSystem(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: codesystem_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([codesystem_resource]);
 });
-

--- a/src/services/communication/communication.service.js
+++ b/src/services/communication/communication.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCommunication = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.COMMUNICATION));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Communication >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Communication = getCommunication(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: communication_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([communication_resource]);
 });
-

--- a/src/services/communicationrequest/communicationrequest.service.js
+++ b/src/services/communicationrequest/communicationrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCommunicationRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.COMMUNICATIONREQUEST));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CommunicationRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CommunicationRequest = getCommunicationRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: communicationrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([communicationrequest_resource]);
 });
-

--- a/src/services/compartmentdefinition/compartmentdefinition.service.js
+++ b/src/services/compartmentdefinition/compartmentdefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCompartmentDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.COMPARTMENTDEFINITION));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('CompartmentDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let CompartmentDefinition = getCompartmentDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: compartmentdefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([compartmentdefinition_resource]);
 });
-

--- a/src/services/composition/composition.service.js
+++ b/src/services/composition/composition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getComposition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.COMPOSITION));};
@@ -77,7 +78,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Composition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Composition = getComposition(base_version);
 	let Meta = getMeta(base_version);
@@ -92,7 +95,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: composition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -226,4 +229,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([composition_resource]);
 });
-

--- a/src/services/conceptmap/conceptmap.service.js
+++ b/src/services/conceptmap/conceptmap.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getConceptMap = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CONCEPTMAP));};
@@ -80,7 +81,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ConceptMap >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ConceptMap = getConceptMap(base_version);
 	let Meta = getMeta(base_version);
@@ -95,7 +98,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: conceptmap_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -235,4 +238,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([conceptmap_resource]);
 });
-

--- a/src/services/condition/condition.service.js
+++ b/src/services/condition/condition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getCondition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CONDITION));};
@@ -82,7 +83,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Condition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Condition = getCondition(base_version);
 	let Meta = getMeta(base_version);
@@ -97,7 +100,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: condition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -241,4 +244,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([condition_resource]);
 });
-

--- a/src/services/consent/consent.service.js
+++ b/src/services/consent/consent.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getConsent = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CONSENT));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Consent >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Consent = getConsent(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: consent_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([consent_resource]);
 });
-

--- a/src/services/contract/contract.service.js
+++ b/src/services/contract/contract.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getContract = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.CONTRACT));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Contract >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Contract = getContract(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: contract_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([contract_resource]);
 });
-

--- a/src/services/dataelement/dataelement.service.js
+++ b/src/services/dataelement/dataelement.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDataElement = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DATAELEMENT));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DataElement >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DataElement = getDataElement(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: dataelement_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([dataelement_resource]);
 });
-

--- a/src/services/detectedissue/detectedissue.service.js
+++ b/src/services/detectedissue/detectedissue.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDetectedIssue = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DETECTEDISSUE));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DetectedIssue >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DetectedIssue = getDetectedIssue(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: detectedissue_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([detectedissue_resource]);
 });
-

--- a/src/services/device/device.service.js
+++ b/src/services/device/device.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDevice = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DEVICE));};
@@ -71,7 +72,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Device >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Device = getDevice(base_version);
 	let Meta = getMeta(base_version);
@@ -86,7 +89,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: device_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -208,4 +211,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([device_resource]);
 });
-

--- a/src/services/devicecomponent/devicecomponent.service.js
+++ b/src/services/devicecomponent/devicecomponent.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDeviceComponent = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DEVICECOMPONENT));};
@@ -63,7 +64,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DeviceComponent >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DeviceComponent = getDeviceComponent(base_version);
 	let Meta = getMeta(base_version);
@@ -78,7 +81,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: devicecomponent_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -184,4 +187,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([devicecomponent_resource]);
 });
-

--- a/src/services/devicemetric/devicemetric.service.js
+++ b/src/services/devicemetric/devicemetric.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDeviceMetric = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DEVICEMETRIC));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DeviceMetric >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DeviceMetric = getDeviceMetric(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: devicemetric_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([devicemetric_resource]);
 });
-

--- a/src/services/devicerequest/devicerequest.service.js
+++ b/src/services/devicerequest/devicerequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDeviceRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DEVICEREQUEST));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DeviceRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DeviceRequest = getDeviceRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: devicerequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([devicerequest_resource]);
 });
-

--- a/src/services/deviceusestatement/deviceusestatement.service.js
+++ b/src/services/deviceusestatement/deviceusestatement.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDeviceUseStatement = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DEVICEUSESTATEMENT));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DeviceUseStatement >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DeviceUseStatement = getDeviceUseStatement(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: deviceusestatement_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([deviceusestatement_resource]);
 });
-

--- a/src/services/diagnosticreport/diagnosticreport.service.js
+++ b/src/services/diagnosticreport/diagnosticreport.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDiagnosticReport = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DIAGNOSTICREPORT));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DiagnosticReport >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DiagnosticReport = getDiagnosticReport(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: diagnosticreport_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([diagnosticreport_resource]);
 });
-

--- a/src/services/documentmanifest/documentmanifest.service.js
+++ b/src/services/documentmanifest/documentmanifest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDocumentManifest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DOCUMENTMANIFEST));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DocumentManifest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DocumentManifest = getDocumentManifest(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: documentmanifest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([documentmanifest_resource]);
 });
-

--- a/src/services/documentreference/documentreference.service.js
+++ b/src/services/documentreference/documentreference.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getDocumentReference = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.DOCUMENTREFERENCE));};
@@ -85,7 +86,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('DocumentReference >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let DocumentReference = getDocumentReference(base_version);
 	let Meta = getMeta(base_version);
@@ -100,7 +103,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: documentreference_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -250,4 +253,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([documentreference_resource]);
 });
-

--- a/src/services/eligibilityrequest/eligibilityrequest.service.js
+++ b/src/services/eligibilityrequest/eligibilityrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEligibilityRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ELIGIBILITYREQUEST));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('EligibilityRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let EligibilityRequest = getEligibilityRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: eligibilityrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([eligibilityrequest_resource]);
 });
-

--- a/src/services/eligibilityresponse/eligibilityresponse.service.js
+++ b/src/services/eligibilityresponse/eligibilityresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEligibilityResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ELIGIBILITYRESPONSE));};
@@ -67,7 +68,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('EligibilityResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let EligibilityResponse = getEligibilityResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -82,7 +85,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: eligibilityresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -196,4 +199,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([eligibilityresponse_resource]);
 });
-

--- a/src/services/encounter/encounter.service.js
+++ b/src/services/encounter/encounter.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEncounter = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ENCOUNTER));};
@@ -80,7 +81,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Encounter >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Encounter = getEncounter(base_version);
 	let Meta = getMeta(base_version);
@@ -95,7 +98,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: encounter_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -235,4 +238,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([encounter_resource]);
 });
-

--- a/src/services/endpoint/endpoint.service.js
+++ b/src/services/endpoint/endpoint.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEndpoint = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ENDPOINT));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Endpoint >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Endpoint = getEndpoint(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: endpoint_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([endpoint_resource]);
 });
-

--- a/src/services/enrollmentrequest/enrollmentrequest.service.js
+++ b/src/services/enrollmentrequest/enrollmentrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEnrollmentRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ENROLLMENTREQUEST));};
@@ -63,7 +64,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('EnrollmentRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let EnrollmentRequest = getEnrollmentRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -78,7 +81,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: enrollmentrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -184,4 +187,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([enrollmentrequest_resource]);
 });
-

--- a/src/services/enrollmentresponse/enrollmentresponse.service.js
+++ b/src/services/enrollmentresponse/enrollmentresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEnrollmentResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.ENROLLMENTRESPONSE));};
@@ -62,7 +63,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('EnrollmentResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let EnrollmentResponse = getEnrollmentResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -77,7 +80,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: enrollmentresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -181,4 +184,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([enrollmentresponse_resource]);
 });
-

--- a/src/services/episodeofcare/episodeofcare.service.js
+++ b/src/services/episodeofcare/episodeofcare.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getEpisodeOfCare = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.EPISODEOFCARE));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('EpisodeOfCare >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let EpisodeOfCare = getEpisodeOfCare(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: episodeofcare_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([episodeofcare_resource]);
 });
-

--- a/src/services/expansionprofile/expansionprofile.service.js
+++ b/src/services/expansionprofile/expansionprofile.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getExpansionProfile = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.EXPANSIONPROFILE));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ExpansionProfile >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ExpansionProfile = getExpansionProfile(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: expansionprofile_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([expansionprofile_resource]);
 });
-

--- a/src/services/explanationofbenefit/explanationofbenefit.service.js
+++ b/src/services/explanationofbenefit/explanationofbenefit.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getExplanationOfBenefit = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.EXPLANATIONOFBENEFIT));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ExplanationOfBenefit >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ExplanationOfBenefit = getExplanationOfBenefit(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: explanationofbenefit_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([explanationofbenefit_resource]);
 });
-

--- a/src/services/familymemberhistory/familymemberhistory.service.js
+++ b/src/services/familymemberhistory/familymemberhistory.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getFamilyMemberHistory = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.FAMILYMEMBERHISTORY));};
@@ -67,7 +68,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('FamilyMemberHistory >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let FamilyMemberHistory = getFamilyMemberHistory(base_version);
 	let Meta = getMeta(base_version);
@@ -82,7 +85,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: familymemberhistory_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -196,4 +199,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([familymemberhistory_resource]);
 });
-

--- a/src/services/flag/flag.service.js
+++ b/src/services/flag/flag.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getFlag = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.FLAG));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Flag >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Flag = getFlag(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: flag_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([flag_resource]);
 });
-

--- a/src/services/goal/goal.service.js
+++ b/src/services/goal/goal.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getGoal = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.GOAL));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Goal >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Goal = getGoal(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: goal_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([goal_resource]);
 });
-

--- a/src/services/graphdefinition/graphdefinition.service.js
+++ b/src/services/graphdefinition/graphdefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getGraphDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.GRAPHDEFINITION));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('GraphDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let GraphDefinition = getGraphDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: graphdefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([graphdefinition_resource]);
 });
-

--- a/src/services/group/group.service.js
+++ b/src/services/group/group.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getGroup = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.GROUP));};
@@ -68,7 +69,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Group >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Group = getGroup(base_version);
 	let Meta = getMeta(base_version);
@@ -83,7 +86,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: group_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -199,4 +202,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([group_resource]);
 });
-

--- a/src/services/guidanceresponse/guidanceresponse.service.js
+++ b/src/services/guidanceresponse/guidanceresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getGuidanceResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.GUIDANCERESPONSE));};
@@ -63,7 +64,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('GuidanceResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let GuidanceResponse = getGuidanceResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -78,7 +81,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: guidanceresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -184,4 +187,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([guidanceresponse_resource]);
 });
-

--- a/src/services/healthcareservice/healthcareservice.service.js
+++ b/src/services/healthcareservice/healthcareservice.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getHealthCareService = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.HEALTHCARESERVICE));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('HealthCareService >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let HealthCareService = getHealthCareService(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: healthcareservice_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([healthcareservice_resource]);
 });
-

--- a/src/services/imagingmanifest/imagingmanifest.service.js
+++ b/src/services/imagingmanifest/imagingmanifest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getImagingManifest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.IMAGINGMANIFEST));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ImagingManifest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ImagingManifest = getImagingManifest(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: imagingmanifest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([imagingmanifest_resource]);
 });
-

--- a/src/services/imagingstudy/imagingstudy.service.js
+++ b/src/services/imagingstudy/imagingstudy.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getImagingStudy = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.IMAGINGSTUDY));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ImagingStudy >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ImagingStudy = getImagingStudy(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: imagingstudy_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([imagingstudy_resource]);
 });
-

--- a/src/services/immunization/immunization.service.js
+++ b/src/services/immunization/immunization.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getImmunization = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.IMMUNIZATION));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Immunization >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Immunization = getImmunization(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: immunization_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([immunization_resource]);
 });
-

--- a/src/services/immunizationrecommendation/immunizationrecommendation.service.js
+++ b/src/services/immunizationrecommendation/immunizationrecommendation.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getImmunizationRecommendation = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.IMMUNIZATIONRECOMMENDATION));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ImmunizationRecommendation >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ImmunizationRecommendation = getImmunizationRecommendation(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: immunizationrecommendation_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([immunizationrecommendation_resource]);
 });
-

--- a/src/services/implementationguide/implementationguide.service.js
+++ b/src/services/implementationguide/implementationguide.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getImplementationGuide = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.IMPLEMENTATIONGUIDE));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ImplementationGuide >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ImplementationGuide = getImplementationGuide(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: implementationguide_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([implementationguide_resource]);
 });
-

--- a/src/services/library/library.service.js
+++ b/src/services/library/library.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getLibrary = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.LIBRARY));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Library >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Library = getLibrary(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: library_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([library_resource]);
 });
-

--- a/src/services/linkage/linkage.service.js
+++ b/src/services/linkage/linkage.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getLinkage = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.LINKAGE));};
@@ -62,7 +63,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Linkage >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Linkage = getLinkage(base_version);
 	let Meta = getMeta(base_version);
@@ -77,7 +80,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: linkage_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -181,4 +184,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([linkage_resource]);
 });
-

--- a/src/services/list/list.service.js
+++ b/src/services/list/list.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getList = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.LIST));};
@@ -71,7 +72,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('List >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let List = getList(base_version);
 	let Meta = getMeta(base_version);
@@ -86,7 +89,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: list_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -208,4 +211,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([list_resource]);
 });
-

--- a/src/services/location/location.service.js
+++ b/src/services/location/location.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getLocation = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.LOCATION));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Location >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Location = getLocation(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: location_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([location_resource]);
 });
-

--- a/src/services/measure/measure.service.js
+++ b/src/services/measure/measure.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMeasure = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEASURE));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Measure >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Measure = getMeasure(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: measure_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([measure_resource]);
 });
-

--- a/src/services/measurereport/measurereport.service.js
+++ b/src/services/measurereport/measurereport.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMeasureReport = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEASUREREPORT));};
@@ -59,7 +60,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MeasureReport >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MeasureReport = getMeasureReport(base_version);
 	let Meta = getMeta(base_version);
@@ -74,7 +77,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: measurereport_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -172,4 +175,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([measurereport_resource]);
 });
-

--- a/src/services/media/media.service.js
+++ b/src/services/media/media.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedia = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDIA));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Media >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Media = getMedia(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: media_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([media_resource]);
 });
-

--- a/src/services/medication/medication.service.js
+++ b/src/services/medication/medication.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedication = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDICATION));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Medication >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Medication = getMedication(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: medication_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([medication_resource]);
 });
-

--- a/src/services/medicationadministration/medicationadministration.service.js
+++ b/src/services/medicationadministration/medicationadministration.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedicationAdministration = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDICATIONADMINISTRATION));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MedicationAdministration >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MedicationAdministration = getMedicationAdministration(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: medicationadministration_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([medicationadministration_resource]);
 });
-

--- a/src/services/medicationdispense/medicationdispense.service.js
+++ b/src/services/medicationdispense/medicationdispense.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedicationDispense = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDICATIONDISPENSE));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MedicationDispense >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MedicationDispense = getMedicationDispense(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: medicationdispense_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([medicationdispense_resource]);
 });
-

--- a/src/services/medicationrequest/medicationrequest.service.js
+++ b/src/services/medicationrequest/medicationrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedicationRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDICATIONREQUEST));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MedicationRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MedicationRequest = getMedicationRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: medicationrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([medicationrequest_resource]);
 });
-

--- a/src/services/medicationstatement/medicationstatement.service.js
+++ b/src/services/medicationstatement/medicationstatement.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMedicationStatement = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MEDICATIONSTATEMENT));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MedicationStatement >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MedicationStatement = getMedicationStatement(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: medicationstatement_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([medicationstatement_resource]);
 });
-

--- a/src/services/messagedefinition/messagedefinition.service.js
+++ b/src/services/messagedefinition/messagedefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMessageDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MESSAGEDEFINITION));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MessageDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MessageDefinition = getMessageDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: messagedefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([messagedefinition_resource]);
 });
-

--- a/src/services/messageheader/messageheader.service.js
+++ b/src/services/messageheader/messageheader.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getMessageHeader = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.MESSAGEHEADER));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('MessageHeader >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let MessageHeader = getMessageHeader(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: messageheader_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([messageheader_resource]);
 });
-

--- a/src/services/namingsystem/namingsystem.service.js
+++ b/src/services/namingsystem/namingsystem.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getNamingSystem = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.NAMINGSYSTEM));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('NamingSystem >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let NamingSystem = getNamingSystem(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: namingsystem_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([namingsystem_resource]);
 });
-

--- a/src/services/nutritionorder/nutritionorder.service.js
+++ b/src/services/nutritionorder/nutritionorder.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getNutritionOrder = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.NUTRITIONORDER));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('NutritionOrder >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let NutritionOrder = getNutritionOrder(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: nutritionorder_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([nutritionorder_resource]);
 });
-

--- a/src/services/observation/observation.service.js
+++ b/src/services/observation/observation.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getObservation = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.OBSERVATION));};
@@ -97,7 +98,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Observation >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Observation = getObservation(base_version);
 	let Meta = getMeta(base_version);
@@ -112,7 +115,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: observation_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -286,4 +289,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([observation_resource]);
 });
-

--- a/src/services/operationdefinition/operationdefinition.service.js
+++ b/src/services/operationdefinition/operationdefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getOperationDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.OPERATIONDEFINITION));};
@@ -74,7 +75,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('OperationDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let OperationDefinition = getOperationDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -89,7 +92,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: operationdefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -217,4 +220,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([operationdefinition_resource]);
 });
-

--- a/src/services/organization/organization.service.js
+++ b/src/services/organization/organization.service.js
@@ -3,6 +3,7 @@
 const { RESOURCES, VERSIONS } = require('@asymmetrik/node-fhir-server-core').constants;
 const { COLLECTION, CLIENT_DB } = require('../../constants');
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 const moment = require('moment-timezone');
 const globals = require('../../globals');
 
@@ -283,7 +284,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Organization >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	// Grab an instance of our DB and collection
 	let db = globals.get(CLIENT_DB);
@@ -523,4 +526,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 		});
 	});
 });
-

--- a/src/services/organization/organization.service.js
+++ b/src/services/organization/organization.service.js
@@ -303,7 +303,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	let doc = Object.assign(cleaned, { _id: id });
 
 	// Insert/update our organization record
-	collection.insertOne({ id: id }, { $set: doc }, { upsert: true }, (err2, res) => {
+	collection.updateOne({ id: id }, { $set: doc }, { upsert: true }, (err2, res) => {
 		if (err2) {
 			logger.error('Error with Organization.create: ', err2);
 			return reject(err2);
@@ -312,7 +312,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 		// save to history
 		let history_collection = db.collection(`${COLLECTION.ORGANIZATION}_${base_version}_History`);
 
-		let history_organization = Object.assign(cleaned, { _id: id + cleaned.meta.versionId });
+		let history_organization = Object.assign(cleaned, { id: id });
 
 		// Insert our organization record to history but don't assign _id
 		return history_collection.insertOne(history_organization, (err3) => {
@@ -321,7 +321,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 				return reject(err3);
 			}
 
-			return resolve({ id: res.value && res.value.id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
+			return resolve({ id: id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
 		});
 
 	});
@@ -371,7 +371,7 @@ module.exports.update = (args, context, logger) => new Promise((resolve, reject)
 			// save to history
 			let history_collection = db.collection(`${COLLECTION.ORGANIZATION}_${base_version}_History`);
 
-			let history_organization = Object.assign(cleaned, { _id: id + cleaned.meta.versionId });
+			let history_organization = Object.assign(cleaned, { id: id });
 
 			// Insert our organization record to history but don't assign _id
 			return history_collection.insertOne(history_organization, (err3) => {
@@ -380,7 +380,7 @@ module.exports.update = (args, context, logger) => new Promise((resolve, reject)
 					return reject(err3);
 				}
 
-				return resolve({ id: res.value && res.value.id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
+				return resolve({ id: id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
 			});
 
 		});

--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -483,7 +483,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	let doc = Object.assign(cleaned, { _id: id });
 
 	// Insert/update our patient record
-	collection.insertOne({ id: id }, { $set: doc }, { upsert: true }, (err2, res) => {
+	collection.updateOne({ id: id }, { $set: doc }, { upsert: true }, (err2, res) => {
 		if (err2) {
 			logger.error('Error with Patient.create: ', err2);
 			return reject(err2);
@@ -492,7 +492,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 		// save to history
 		let history_collection = db.collection(`${COLLECTION.PATIENT}_${base_version}_History`);
 
-		let history_patient = Object.assign(cleaned, { _id: id + cleaned.meta.versionId });
+		let history_patient = Object.assign(cleaned, { id: id });
 
 		// Insert our patient record to history but don't assign _id
 		return history_collection.insertOne(history_patient, (err3) => {
@@ -501,7 +501,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 				return reject(err3);
 			}
 
-			return resolve({ id: res.value && res.value.id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
+			return resolve({ id: id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
 		});
 
 	});
@@ -551,7 +551,7 @@ module.exports.update = (args, context, logger) => new Promise((resolve, reject)
 			// save to history
 			let history_collection = db.collection(`${COLLECTION.PATIENT}_${base_version}_History`);
 
-			let history_patient = Object.assign(cleaned, { _id: id + cleaned.meta.versionId });
+			let history_patient = Object.assign(cleaned, { id: id });
 
 			// Insert our patient record to history but don't assign _id
 			return history_collection.insertOne(history_patient, (err3) => {
@@ -619,6 +619,7 @@ module.exports.searchByVersionId = (args, context, logger) => new Promise((resol
 
 	let db = globals.get(CLIENT_DB);
 	let history_collection = db.collection(`${COLLECTION.PATIENT}_${base_version}_History`);
+
 	// Query our collection for this observation
 	history_collection.findOne({ id: id.toString(), 'meta.versionId': `${version_id}` }, (err, patient) => {
 		if (err) {

--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -560,7 +560,7 @@ module.exports.update = (args, context, logger) => new Promise((resolve, reject)
 					return reject(err3);
 				}
 
-				return resolve({ id: doc.id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
+				return resolve({ id: id, created: res.lastErrorObject && !res.lastErrorObject.updatedExisting, resource_version: doc.meta.versionId });
 			});
 
 		});

--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES, VERSIONS } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 const { COLLECTION, CLIENT_DB } = require('../../constants');
 const moment = require('moment-timezone');
 const globals = require('../../globals');
@@ -463,7 +464,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Patient >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	// Grab an instance of our DB and collection
 	let db = globals.get(CLIENT_DB);
@@ -703,4 +706,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 		});
 	});
 });
-

--- a/src/services/paymentnotice/paymentnotice.service.js
+++ b/src/services/paymentnotice/paymentnotice.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPaymentNotice = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PAYMENTNOTICE));};
@@ -67,7 +68,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('PaymentNotice >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let PaymentNotice = getPaymentNotice(base_version);
 	let Meta = getMeta(base_version);
@@ -82,7 +85,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: paymentnotice_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -196,4 +199,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([paymentnotice_resource]);
 });
-

--- a/src/services/paymentreconciliation/paymentreconciliation.service.js
+++ b/src/services/paymentreconciliation/paymentreconciliation.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPaymentReconciliation = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PAYMENTRECONCILIATION));};
@@ -67,7 +68,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('PaymentReconciliation >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let PaymentReconciliation = getPaymentReconciliation(base_version);
 	let Meta = getMeta(base_version);
@@ -82,7 +85,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: paymentreconciliation_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -196,4 +199,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([paymentreconciliation_resource]);
 });
-

--- a/src/services/person/person.service.js
+++ b/src/services/person/person.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPerson = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PERSON));};
@@ -78,7 +79,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Person >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Person = getPerson(base_version);
 	let Meta = getMeta(base_version);
@@ -93,7 +96,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: person_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -229,4 +232,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([person_resource]);
 });
-

--- a/src/services/plandefinition/plandefinition.service.js
+++ b/src/services/plandefinition/plandefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPlanDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PLANDEFINITION));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('PlanDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let PlanDefinition = getPlanDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: plandefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([plandefinition_resource]);
 });
-

--- a/src/services/practitioner/practitioner.service.js
+++ b/src/services/practitioner/practitioner.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPractitioner = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PRACTITIONER));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Practitioner >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Practitioner = getPractitioner(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: practitioner_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([practitioner_resource]);
 });
-

--- a/src/services/practitionerrole/practitionerrole.service.js
+++ b/src/services/practitionerrole/practitionerrole.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getPractitionerRole = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PRACTITIONERROLE));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('PractitionerRole >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let PractitionerRole = getPractitionerRole(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: practitionerrole_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([practitionerrole_resource]);
 });
-

--- a/src/services/procedure/procedure.service.js
+++ b/src/services/procedure/procedure.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getProcedure = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PROCEDURE));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Procedure >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Procedure = getProcedure(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: procedure_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([procedure_resource]);
 });
-

--- a/src/services/procedurerequest/procedurerequest.service.js
+++ b/src/services/procedurerequest/procedurerequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getProcedureRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PROCEDUREREQUEST));};
@@ -79,7 +80,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ProcedureRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ProcedureRequest = getProcedureRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -94,7 +97,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: procedurerequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -232,4 +235,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([procedurerequest_resource]);
 });
-

--- a/src/services/processrequest/processrequest.service.js
+++ b/src/services/processrequest/processrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getProcessRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PROCESSREQUEST));};
@@ -63,7 +64,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ProcessRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ProcessRequest = getProcessRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -78,7 +81,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: processrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -184,4 +187,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([processrequest_resource]);
 });
-

--- a/src/services/processresponse/processresponse.service.js
+++ b/src/services/processresponse/processresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getProcessResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PROCESSRESPONSE));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ProcessResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ProcessResponse = getProcessResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: processresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([processresponse_resource]);
 });
-

--- a/src/services/provenance/provenance.service.js
+++ b/src/services/provenance/provenance.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getProvenance = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.PROVENANCE));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Provenance >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Provenance = getProvenance(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: provenance_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([provenance_resource]);
 });
-

--- a/src/services/questionnaire/questionnaire.service.js
+++ b/src/services/questionnaire/questionnaire.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getQuestionnaire = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.QUESTIONNAIRE));};
@@ -71,7 +72,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Questionnaire >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Questionnaire = getQuestionnaire(base_version);
 	let Meta = getMeta(base_version);
@@ -86,7 +89,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: questionnaire_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -208,4 +211,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([questionnaire_resource]);
 });
-

--- a/src/services/questionnaireresponse/questionnaireresponse.service.js
+++ b/src/services/questionnaireresponse/questionnaireresponse.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getQuestionnaireResponse = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.QUESTIONNAIRERESPONSE));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('QuestionnaireResponse >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let QuestionnaireResponse = getQuestionnaireResponse(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: questionnaireresponse_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([questionnaireresponse_resource]);
 });
-

--- a/src/services/referralrequest/referralrequest.service.js
+++ b/src/services/referralrequest/referralrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getReferralRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.REFERRALREQUEST));};
@@ -78,7 +79,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ReferralRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ReferralRequest = getReferralRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -93,7 +96,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: referralrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -229,4 +232,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([referralrequest_resource]);
 });
-

--- a/src/services/relatedperson/relatedperson.service.js
+++ b/src/services/relatedperson/relatedperson.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getRelatedPerson = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.RELATEDPERSON));};
@@ -75,7 +76,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('RelatedPerson >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let RelatedPerson = getRelatedPerson(base_version);
 	let Meta = getMeta(base_version);
@@ -90,7 +93,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: relatedperson_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -220,4 +223,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([relatedperson_resource]);
 });
-

--- a/src/services/requestgroup/requestgroup.service.js
+++ b/src/services/requestgroup/requestgroup.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getRequestGroup = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.REQUESTGROUP));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('RequestGroup >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let RequestGroup = getRequestGroup(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: requestgroup_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([requestgroup_resource]);
 });
-

--- a/src/services/researchstudy/researchstudy.service.js
+++ b/src/services/researchstudy/researchstudy.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getResearchStudy = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.RESEARCHSTUDY));};
@@ -72,7 +73,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ResearchStudy >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ResearchStudy = getResearchStudy(base_version);
 	let Meta = getMeta(base_version);
@@ -87,7 +90,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: researchstudy_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -211,4 +214,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([researchstudy_resource]);
 });
-

--- a/src/services/researchsubject/researchsubject.service.js
+++ b/src/services/researchsubject/researchsubject.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getResearchSubject = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.RESEARCHSUBJECT));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ResearchSubject >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ResearchSubject = getResearchSubject(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: researchsubject_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([researchsubject_resource]);
 });
-

--- a/src/services/riskassessment/riskassessment.service.js
+++ b/src/services/riskassessment/riskassessment.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getRiskAssessment = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.RISKASSESSMENT));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('RiskAssessment >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let RiskAssessment = getRiskAssessment(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: riskassessment_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([riskassessment_resource]);
 });
-

--- a/src/services/schedule/schedule.service.js
+++ b/src/services/schedule/schedule.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSchedule = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SCHEDULE));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Schedule >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Schedule = getSchedule(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: schedule_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([schedule_resource]);
 });
-

--- a/src/services/searchparameter/searchparameter.service.js
+++ b/src/services/searchparameter/searchparameter.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSearchParameter = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SEARCHPARAMETER));};
@@ -73,7 +74,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('SearchParameter >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let SearchParameter = getSearchParameter(base_version);
 	let Meta = getMeta(base_version);
@@ -88,7 +91,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: searchparameter_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -214,4 +217,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([searchparameter_resource]);
 });
-

--- a/src/services/sequence/sequence.service.js
+++ b/src/services/sequence/sequence.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSequence = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SEQUENCE));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Sequence >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Sequence = getSequence(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: sequence_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([sequence_resource]);
 });
-

--- a/src/services/servicedefinition/servicedefinition.service.js
+++ b/src/services/servicedefinition/servicedefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getServiceDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SERVICEDEFINITION));};
@@ -76,7 +77,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ServiceDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ServiceDefinition = getServiceDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -91,7 +94,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: servicedefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -223,4 +226,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([servicedefinition_resource]);
 });
-

--- a/src/services/slot/slot.service.js
+++ b/src/services/slot/slot.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSlot = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SLOT));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Slot >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Slot = getSlot(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: slot_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([slot_resource]);
 });
-

--- a/src/services/specimen/specimen.service.js
+++ b/src/services/specimen/specimen.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSpecimen = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SPECIMEN));};
@@ -71,7 +72,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Specimen >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Specimen = getSpecimen(base_version);
 	let Meta = getMeta(base_version);
@@ -86,7 +89,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: specimen_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -208,4 +211,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([specimen_resource]);
 });
-

--- a/src/services/structuredefinition/structuredefinition.service.js
+++ b/src/services/structuredefinition/structuredefinition.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getStructureDefinition = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.STRUCTUREDEFINITION));};
@@ -81,7 +82,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('StructureDefinition >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let StructureDefinition = getStructureDefinition(base_version);
 	let Meta = getMeta(base_version);
@@ -96,7 +99,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: structuredefinition_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -238,4 +241,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([structuredefinition_resource]);
 });
-

--- a/src/services/structuremap/structuremap.service.js
+++ b/src/services/structuremap/structuremap.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getStructureMap = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.STRUCTUREMAP));};
@@ -69,7 +70,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('StructureMap >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let StructureMap = getStructureMap(base_version);
 	let Meta = getMeta(base_version);
@@ -84,7 +87,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: structuremap_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -202,4 +205,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([structuremap_resource]);
 });
-

--- a/src/services/subscription/subscription.service.js
+++ b/src/services/subscription/subscription.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSubscription = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SUBSCRIPTION));};
@@ -66,7 +67,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Subscription >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Subscription = getSubscription(base_version);
 	let Meta = getMeta(base_version);
@@ -81,7 +84,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: subscription_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -193,4 +196,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([subscription_resource]);
 });
-

--- a/src/services/substance/substance.service.js
+++ b/src/services/substance/substance.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSubstance = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SUBSTANCE));};
@@ -67,7 +68,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Substance >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Substance = getSubstance(base_version);
 	let Meta = getMeta(base_version);
@@ -82,7 +85,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: substance_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -196,4 +199,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([substance_resource]);
 });
-

--- a/src/services/supplydelivery/supplydelivery.service.js
+++ b/src/services/supplydelivery/supplydelivery.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSupplyDelivery = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SUPPLYDELIVERY));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('SupplyDelivery >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let SupplyDelivery = getSupplyDelivery(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: supplydelivery_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([supplydelivery_resource]);
 });
-

--- a/src/services/supplyrequest/supplyrequest.service.js
+++ b/src/services/supplyrequest/supplyrequest.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getSupplyRequest = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.SUPPLYREQUEST));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('SupplyRequest >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let SupplyRequest = getSupplyRequest(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: supplyrequest_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([supplyrequest_resource]);
 });
-

--- a/src/services/task/task.service.js
+++ b/src/services/task/task.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getTask = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.TASK));};
@@ -79,7 +80,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('Task >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let Task = getTask(base_version);
 	let Meta = getMeta(base_version);
@@ -94,7 +97,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: task_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -232,4 +235,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([task_resource]);
 });
-

--- a/src/services/testreport/testreport.service.js
+++ b/src/services/testreport/testreport.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getTestReport = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.TESTREPORT));};
@@ -65,7 +66,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('TestReport >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let TestReport = getTestReport(base_version);
 	let Meta = getMeta(base_version);
@@ -80,7 +83,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: testreport_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -190,4 +193,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([testreport_resource]);
 });
-

--- a/src/services/testscript/testscript.service.js
+++ b/src/services/testscript/testscript.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getTestScript = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.TESTSCRIPT));};
@@ -70,7 +71,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('TestScript >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let TestScript = getTestScript(base_version);
 	let Meta = getMeta(base_version);
@@ -85,7 +88,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: testscript_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -205,4 +208,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([testscript_resource]);
 });
-

--- a/src/services/valueset/valueset.service.js
+++ b/src/services/valueset/valueset.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getValueSet = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.VALUESET));};
@@ -71,7 +72,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('ValueSet >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let ValueSet = getValueSet(base_version);
 	let Meta = getMeta(base_version);
@@ -86,7 +89,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: valueset_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -208,4 +211,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([valueset_resource]);
 });
-

--- a/src/services/visionprescription/visionprescription.service.js
+++ b/src/services/visionprescription/visionprescription.service.js
@@ -2,6 +2,7 @@
 
 const { RESOURCES } = require('@asymmetrik/node-fhir-server-core').constants;
 const FHIRServer = require('@asymmetrik/node-fhir-server-core');
+const { ObjectID } = require('mongodb');
 
 let getVisionPrescription = (base_version) => {
 	return require(FHIRServer.resolveFromVersion(base_version, RESOURCES.VISIONPRESCRIPTION));};
@@ -64,7 +65,9 @@ module.exports.searchById = (args, context, logger) => new Promise((resolve, rej
 module.exports.create = (args, context, logger) => new Promise((resolve, reject) => {
 	logger.info('VisionPrescription >>> create');
 
-	let { base_version, id, resource } = args;
+	let { base_version, resource } = args;
+	// Make sure to use this ID when inserting this resource
+	let id = new ObjectID().toString();
 
 	let VisionPrescription = getVisionPrescription(base_version);
 	let Meta = getMeta(base_version);
@@ -79,7 +82,7 @@ module.exports.create = (args, context, logger) => new Promise((resolve, reject)
 	// TODO: save record to database
 
 	// Return Id
-	resolve({ id: visionprescription_resource.id });
+	resolve({ id });
 });
 
 module.exports.update = (args, context, logger) => new Promise((resolve, reject) => {
@@ -187,4 +190,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 	// Return Array
 	resolve([visionprescription_resource]);
 });
-


### PR DESCRIPTION
Currently a draft.

* Pulled in updates from other PR
* All create services now generate an ObjectID and use that - (Issue #22)
* Fixed issues with Patient and Organization appending to an ID when adding to the history collection
* Fixed resolvers in create and update for Patient and Organization, they were not resolving the correct id