### PR TITLE
Bug/date param

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@asymmetrik/node-fhir-server-core": "git+https://github.com/Asymmetrik/node-fhir-server-core.git",
     "moment-timezone": "^0.5.14",
     "mongo": "^0.1.0",
-    "var": "^0.3.2"
+    "var": "^0.3.2",
+    "xregexp": "^4.2.0"
   },
   "devDependencies": {
     "cross-env": "^5.1.6",

--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -118,11 +118,11 @@ let buildStu3SearchQuery = (args) =>	 {
 	}
 
 	if (birthdate) {
-		query.birthDate = dateQueryBuilder(birthdate, 'date', '');
+		query.birthDate = dateQueryBuilder(birthdate);
 	}
 
 	if (death_date) {
-		query.deceasedDateTime = dateQueryBuilder(death_date, 'dateTime', '');
+		query.deceasedDateTime = dateQueryBuilder(death_date);
 	}
 
 	if (deceased) {
@@ -307,11 +307,11 @@ let buildDstu2SearchQuery = (args) =>	 {
 	}
 
 	if (birthdate) {
-		query.birthDate = dateQueryBuilder(birthdate, 'date', '');
+		query.birthDate = dateQueryBuilder(birthdate);
 	}
 
 	if (death_date) {
-		query.deceasedDateTime = dateQueryBuilder(death_date, 'dateTime', '');
+		query.deceasedDateTime = dateQueryBuilder(death_date);
 	}
 
 	if (deceased) {

--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -703,4 +703,3 @@ module.exports.historyById = (args, context, logger) => new Promise((resolve, re
 		});
 	});
 });
-

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -252,138 +252,155 @@ let rDay = day2 - Math.floor((m1 * 306 + 5) / 10) + 1;
 return year.toString() + '-' + ('0' + month).slice(-2) + '-' + ('0' + rDay).slice(-2);
 };
 
-//deals with date, dateTime, instant, period, and timing
-//use like this: query['whatever'] = dateQueryBuilder(whatever, 'dateTime'), but it's different for period and timing
-//the condition service has some examples you might want to look at.
-//can't handle prefixes yet!
-//Also doesn't work foe when things are stored in different time zones in the .json files (with the + or -)
-//  UNLESS, the search parameter is teh exact same as what is stored.  So, if something is stored as 2016-06-03T05:00-03:00, then the search parameter must be 2016-06-03T05:00-03:00
-//It's important to make sure formatting is right, dont forget a leading 0 when dealing with single digit times.
+// deals with date, dateTime, instant, period, and timing
+// use like this: query['whatever'] = dateQueryBuilder(whatever, 'dateTime'), but it's different for period and timing
+// the condition service has some examples you might want to look at.
+// can't handle prefixes yet!
+// Also doesn't work foe when things are stored in different time zones in the .json files (with the + or -)
+// UNLESS, the search parameter is teh exact same as what is stored.  So, if something is stored as 2016-06-03T05:00-03:00, then the search parameter must be 2016-06-03T05:00-03:00
+// It's important to make sure formatting is right, dont forget a leading 0 when dealing with single digit times.
+/**
+* TODO:
+* REMOVE THIS, date is a moment object and this whole function expects a datestring
+* then uses regex to parse the datestring and manipulate pieces of it. Moment objects
+* have a toObject method which would negate the need for regex and matching. We also need
+* to verify the built queries are correct. Recommending we start from scratch
+* with this and add unit tests.
+*/
 let dateQueryBuilder = function (date, type, path) {
-let regex = /^(\D{2})?(\d{4})(-\d{2})?(-\d{2})?(?:(T\d{2}:\d{2})(:\d{2})?)?(Z|(\+|-)(\d{2}):(\d{2}))?$/;
-let match = date.match(regex);
-let str = '';
-let toRet = [];
-let pArr = []; //will have other possibilities such as just year, just year and month, etc
-let prefix = '$eq';
-if (match && match.length >= 1 ) {
-	if (match[1]) {
+	let formatted_date = date = date.format();
+	let regex = /^(\D{2})?(\d{4})(-\d{2})?(-\d{2})?(?:(T\d{2}:\d{2})(:\d{2})?)?(Z|(\+|-)(\d{2}):(\d{2}))?$/;
+	let match = formatted_date.match(regex);
+	let str = '';
+	let toRet = [];
+	let pArr = []; //will have other possibilities such as just year, just year and month, etc
+	let prefix = '$eq';
+	if (match && match.length >= 1 ) {
+
+		if (match[1]) {
 			// replace prefix with mongo specific comparators
 			prefix = '$' + match[1].replace('ge', 'gte').replace('le', 'lte');
 		}
-	if (type === 'date') { //if its just a date, we don't have to worry about time components
-	if (prefix === '$eq') {
-		//add parts of date that are available
-		for (let i = 2; i < 5; i++) { //add up the date parts in a string
-		if (match[i]) {
-			str = str + match[i];
-			pArr[i - 2] = str + '$';
-		}
-		}
-		//below we have to check if the search gave more information than what is actually stored
-		return {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + pArr[0] + ')|(?:' + pArr[1] + ')|(?:' + pArr[2] + ')', 'i')};
-	}
-	}
 
-	if (type === 'dateTime' || type === 'instant' || type === 'period' || type === 'timing') { //now we have to worry about hours, minutes, seconds, and TIMEZONES
-	if (prefix === '$eq') {
-		if (match[5]) { //to see if time is included
-		for (let i = 2; i < 6; i++) {
-			str = str + match[i];
-			if (i === 5) {
-			pArr[i - 2] = str + 'Z?$';
-			} else {
-			pArr[i - 2] = str + '$';
+		if (type === 'date') { //if its just a date, we don't have to worry about time components
+			if (prefix === '$eq') {
+				//add parts of date that are available
+				for (let i = 2; i < 5; i++) { //add up the date parts in a string
+					if (match[i]) {
+						str = str + match[i];
+						pArr[i - 2] = str + '$';
+					}
+				}
+				//below we have to check if the search gave more information than what is actually stored
+				return {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + pArr[0] + ')|(?:' + pArr[1] + ')|(?:' + pArr[2] + ')', 'i')};
 			}
 		}
-		if (type === 'instant'){
-			if (match[6]) { //to check if seconds were included or not
-			str = str + match[6];
-			}
-		}
-		if (match[9]) { // we know there is a +|-hh:mm at the end
-			let mins = 0;
-			let hrs = 0;
-			if (match[8] === '+') { //time is ahead of UTC so we must subtract
-			let hM = match[5].split(':');
-			hM[0] = hM[0].replace('T', '');
-			mins = Number(hM[1]) - Number(match[10]);
-			hrs = Number(hM[0]) - Number(match[9]);
-			if (mins < 0) { //when we subtract the minutes and go below zero, we need to remove an hour
-				mins = mod(mins, 60);
-				hrs = hrs - 1;
-			}
-			if (hrs < 0) { //when hours goes below zero, we have to adjust the date
-				hrs = mod(hrs, 24);
-				str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))) - 1);
-			} else {
-				str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))));
-			}
-			} else { //time is behind UTC so we add
-			let hM = match[5].split(':');
-			hM[0] = hM[0].replace('T', '');
-			mins = Number(hM[1]) + Number(match[10]);
-			hrs = Number(hM[0]) + Number(match[9]);
-			if (mins > 59) { //if we go above 59, we need to increase hours
-				mins = mod(mins, 60);
-				hrs = hrs + 1;
-			}
-			if (hrs > 23) { //if we go above 23 hours, new day
-				hrs = mod(hrs, 24);
-				str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))) + 1);
-			} else {
-				str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))));
-			}
-			}
-			pArr[5] = str + '$';
-			str = str + 'T' + ('0' + hrs).slice(-2) + ':' + ('0' + mins).slice(-2); //proper formatting for leading 0's
-			let match2 = str.match(/^(\d{4})(-\d{2})?(-\d{2})(?:(T\d{2}:\d{2})(:\d{2})?)?/);
-			if (match2 && match2.length >= 1) {
-			pArr[0] = match2[1] + '$'; //YYYY
-			pArr[1] = match2[1] + match2[2] + '$'; //YYYY-MM
-			pArr[2] = match2[1] + match2[2] + match2[3] + '$'; //YYYY-MM-DD
-			pArr[3] = match2[1] + match2[2] + match2[3] + 'T' + ('0' + hrs).slice(-2) + ':' + ('0' + mins).slice(-2) + 'Z?$';
-			}
-			if (match[6]) { //to check if seconds were included or not
-			pArr[4] = str + ':' + ('0' + match[6]).slice(-2) + 'Z?$';
-			str = str + match[6];
-			}
-			if (!pArr[4]) { //fill empty spots in pArr with ^$ to make sure it can't just match with nothing
-			pArr[4] = '^$';
-			}
-		}
-		} else {
-		for (let i = 2; i < 5; i++) { //add up the date parts in a string, done to make sure to update anything if timezone changed anything
-			if (match[i]) {
-			str = str + match[i];
-			pArr[i - 2] = str + '$';
-			}
-		}
-		}
-		let regPoss = {$regex: new RegExp('^' + '(?:' + pArr[0] + ')|(?:' + pArr[1] + ')|(?:' + pArr[2] + ')|(?:' + pArr[3] + ')|(?:' + pArr[4] + ')')};
-		if (type === 'period'){
-		str = str + 'Z';
-		let pS = path + '.start';
-		let pE = path + '.end';
-		toRet = [{$and: [{[pS]: {$lte: str}}, {$or: [{[pE]: {$gte: str}}, {[pE]: regPoss}]}]}, {$and: [{[pS]: {$lte: str}}, {[pE]: undefined}]},
-		{$and: [{$or: [{[pE]: {$gte: str}}, {[pE]: regPoss}]}, {[pS]: undefined}]}];
-		return toRet;
-		}
-		let tempFill = pArr.toString().replace(/,/g, ')|(?:') + ')'; //turning the pArr to a string that can be used as a regex
-		if (type === 'timing') {
-		let pDT = path + '.event';
-		let pBPS = path + '.repeat.boundsPeriod.start';
-		let pBPE = path + '.repeat.boundsPeriod.end';
-		toRet = [{[pDT]: {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + match[0].replace('+', '\\+') + ')|(?:' + tempFill, 'i')}},
-		{$and: [{[pBPS]: {$lte: str}}, {$or: [{[pBPE]: {$gte: str}}, {[pBPE]: regPoss}]}]}, {$and: [{[pBPS]: {$lte: str}}, {[pBPE]: undefined}]},
-	{$and: [{$or: [{[pBPE]: {$gte: str}}, {[pBPE]: regPoss}]}, {[pBPS]: undefined}]}];
-	return toRet;
-		}
-		return {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + match[0].replace('+', '\\+') + ')|(?:' + tempFill, 'i')};
-	}
-	}
 
-}
+		if (type === 'dateTime' || type === 'instant' || type === 'period' || type === 'timing') { //now we have to worry about hours, minutes, seconds, and TIMEZONES
+			if (prefix === '$eq') {
+				if (match[5]) { //to see if time is included
+					for (let i = 2; i < 6; i++) {
+							str = str + match[i];
+						if (i === 5) {
+							pArr[i - 2] = str + 'Z?$';
+						} else {
+							pArr[i - 2] = str + '$';
+						}
+					}
+					if (type === 'instant'){
+						if (match[6]) { //to check if seconds were included or not
+							str = str + match[6];
+						}
+					}
+
+					if (match[9]) { // we know there is a +|-hh:mm at the end
+						let mins = 0;
+						let hrs = 0;
+						if (match[8] === '+') { //time is ahead of UTC so we must subtract
+							let hM = match[5].split(':');
+							hM[0] = hM[0].replace('T', '');
+							mins = Number(hM[1]) - Number(match[10]);
+							hrs = Number(hM[0]) - Number(match[9]);
+							if (mins < 0) { //when we subtract the minutes and go below zero, we need to remove an hour
+								mins = mod(mins, 60);
+								hrs = hrs - 1;
+							}
+							if (hrs < 0) { //when hours goes below zero, we have to adjust the date
+								hrs = mod(hrs, 24);
+								str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))) - 1);
+							} else {
+								str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))));
+							}
+						} else { //time is behind UTC so we add
+							let hM = match[5].split(':');
+							hM[0] = hM[0].replace('T', '');
+							mins = Number(hM[1]) + Number(match[10]);
+							hrs = Number(hM[0]) + Number(match[9]);
+							if (mins > 59) { //if we go above 59, we need to increase hours
+								mins = mod(mins, 60);
+								hrs = hrs + 1;
+							}
+							if (hrs > 23) { //if we go above 23 hours, new day
+								hrs = mod(hrs, 24);
+								str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))) + 1);
+							} else {
+								str = getDateFromNum(getDayNum(Number(match[2]), Number(match[3].replace('-', '')), Number(match[4].replace('-', ''))));
+							}
+						}
+
+						pArr[5] = str + '$';
+						str = str + 'T' + ('0' + hrs).slice(-2) + ':' + ('0' + mins).slice(-2); //proper formatting for leading 0's
+						let match2 = str.match(/^(\d{4})(-\d{2})?(-\d{2})(?:(T\d{2}:\d{2})(:\d{2})?)?/);
+
+						if (match2 && match2.length >= 1) {
+							pArr[0] = match2[1] + '$'; //YYYY
+							pArr[1] = match2[1] + match2[2] + '$'; //YYYY-MM
+							pArr[2] = match2[1] + match2[2] + match2[3] + '$'; //YYYY-MM-DD
+							pArr[3] = match2[1] + match2[2] + match2[3] + 'T' + ('0' + hrs).slice(-2) + ':' + ('0' + mins).slice(-2) + 'Z?$';
+						}
+
+						if (match[6]) { //to check if seconds were included or not
+							pArr[4] = str + ':' + ('0' + match[6]).slice(-2) + 'Z?$';
+							str = str + match[6];
+						}
+
+						if (!pArr[4]) { //fill empty spots in pArr with ^$ to make sure it can't just match with nothing
+							pArr[4] = '^$';
+						}
+					}
+				} else {
+					for (let i = 2; i < 5; i++) { //add up the date parts in a string, done to make sure to update anything if timezone changed anything
+						if (match[i]) {
+							str = str + match[i];
+							pArr[i - 2] = str + '$';
+						}
+					}
+				}
+
+				let regPoss = {$regex: new RegExp('^' + '(?:' + pArr[0] + ')|(?:' + pArr[1] + ')|(?:' + pArr[2] + ')|(?:' + pArr[3] + ')|(?:' + pArr[4] + ')')};
+				if (type === 'period'){
+					str = str + 'Z';
+					let pS = path + '.start';
+					let pE = path + '.end';
+					toRet = [{$and: [{[pS]: {$lte: str}}, {$or: [{[pE]: {$gte: str}}, {[pE]: regPoss}]}]}, {$and: [{[pS]: {$lte: str}}, {[pE]: undefined}]},
+					{$and: [{$or: [{[pE]: {$gte: str}}, {[pE]: regPoss}]}, {[pS]: undefined}]}];
+					return toRet;
+				}
+
+				let tempFill = pArr.toString().replace(/,/g, ')|(?:') + ')'; //turning the pArr to a string that can be used as a regex
+				if (type === 'timing') {
+					let pDT = path + '.event';
+					let pBPS = path + '.repeat.boundsPeriod.start';
+					let pBPE = path + '.repeat.boundsPeriod.end';
+					toRet = [{[pDT]: {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + match[0].replace('+', '\\+') + ')|(?:' + tempFill, 'i')}},
+					{$and: [{[pBPS]: {$lte: str}}, {$or: [{[pBPE]: {$gte: str}}, {[pBPE]: regPoss}]}]}, {$and: [{[pBPS]: {$lte: str}}, {[pBPE]: undefined}]},
+					{$and: [{$or: [{[pBPE]: {$gte: str}}, {[pBPE]: regPoss}]}, {[pBPS]: undefined}]}];
+					return toRet;
+				}
+				return {$regex: new RegExp('^' + '(?:' + str + ')|(?:' + match[0].replace('+', '\\+') + ')|(?:' + tempFill, 'i')};
+			}
+		}
+	}
 };
 
 /**

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -273,7 +273,7 @@ let dateQueryBuilder = function (target, currentDateTimeOverride) {
     }
 
     // Use a regular expression to parse out the attributes of the incoming query.
-    const dateRegex = xRegExp(`
+    const dateRegex = xRegExp(`^
         (?<prefix>  [A-Za-z]{2} )?     # prefix
         (?<year>    [0-9]{4} )    -?   # year (required)
         (?<month>   [0-9]{2} )?   -?   # month
@@ -282,7 +282,7 @@ let dateQueryBuilder = function (target, currentDateTimeOverride) {
         (?<minute>  [0-9]{2} )?   :?   # minute
         (?<second>  [0-9]{2} )?        # second
         (?<timezone>   .*)?            # timezone
-        `, 'x');
+        $`, 'x');
     let parsedDatetime = xRegExp.exec(target, dateRegex);
 
     // Map of the date attributes and their properties in order of decreasing granularity
@@ -328,17 +328,17 @@ let dateQueryBuilder = function (target, currentDateTimeOverride) {
 
     // An object mapping the possible query prefixes to the modifiers used to build an appropriate mongo query
     const queryModifiers = {
-        'eq': '',			// equal
+        eq: '',			    // equal
         undefined: '',		// equal (implied)
         null: '',			// equal (implied)
-        'ne': 'ne',			// not equal
-        'gt': '$gt',		// greater than
-        'ge': '$gte',		// greater than or equal to
-        'lt': '$lt',		// less than
-        'le': '$lte',		// less than or equal to
-        'sa': '$gt',		// starts after (equivalent to 'greater than' for dates)
-        'eb': '$lt',		// ends before (equivalent to 'less than' for dates)
-        'ap': 'ap'			// approximately
+        ne: 'ne',			// not equal
+        gt: '$gt',		    // greater than
+        ge: '$gte',		    // greater than or equal to
+        lt: '$lt',		    // less than
+        le: '$lte',		    // less than or equal to
+        sa: '$gt',		    // starts after (equivalent to 'greater than' for dates)
+        eb: '$lt',		    // ends before (equivalent to 'less than' for dates)
+        ap: 'ap'			// approximately
     };
 
     // Retrieve the appropriate query modifier for the supplied prefix

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -266,10 +266,10 @@ let quantityQueryBuilder = function (target, field) {
  * TODO - Check that upstream sanitization guarantees a valid ISO date string as well as a valid query prefix.
  * TODO - Also need to make sure the timezone information is UTC.
  */
-let dateQueryBuilder = function (date, currentDateTimeOverride) {
+let dateQueryBuilder = function (target, currentDateTimeOverride) {
     // If the date is a moment object, turn it into an ISO Date String and return it as the query
-    if (moment.isMoment(date)) {
-		return date.toISOString();
+    if (moment.isMoment(target)) {
+		return target.toISOString();
     }
 
     // Use a regular expression to parse out the attributes of the incoming query.
@@ -283,7 +283,7 @@ let dateQueryBuilder = function (date, currentDateTimeOverride) {
         (?<second>  [0-9]{2} )?        # second
         (?<timezone>   .*)?            # timezone
         `, 'x');
-    let parsedDatetime = xRegExp.exec(date, dateRegex);
+    let parsedDatetime = xRegExp.exec(target, dateRegex);
 
     // Map of the date attributes and their properties in order of decreasing granularity
     // Default values are provided here and used if values aren't provided in the query
@@ -323,7 +323,7 @@ let dateQueryBuilder = function (date, currentDateTimeOverride) {
         [dateAttributes.get('year').value, dateAttributes.get('month').value, dateAttributes.get('day').value].join('-')
         + 'T'
         + [dateAttributes.get('hour').value, dateAttributes.get('minute').value, dateAttributes.get('second').value].join(':'),
-		'UTC' //FIXME assuming UTC.
+		'UTC' // assuming UTC.
     );
 
     // An object mapping the possible query prefixes to the modifiers used to build an appropriate mongo query
@@ -359,8 +359,6 @@ let dateQueryBuilder = function (date, currentDateTimeOverride) {
 
     } else if (queryModifier === 'ne') {
         // Construct a query for 'not equal' if the 'ne' prefix was provided
-        // TODO - This works, but I'm not sure that it's the best way to do things. The only alternative I could think
-        // TODO - of was to use mongo's $or key, but that would require some refactoring because of key structure.
 
         // Construct a regex that matches ISO date strings that don't match the pattern to whatever level of
         // granularity is appropriate based on the supplied date. For example, ne2000-01 will match all dates
@@ -396,6 +394,7 @@ let dateQueryBuilder = function (date, currentDateTimeOverride) {
     }
     return dateQuery;
 };
+
 
 /**
  * @name compositeQueryBuilder

--- a/src/utils/querybuilder.util.js
+++ b/src/utils/querybuilder.util.js
@@ -1,5 +1,5 @@
 const moment = require('moment-timezone');
-const XRegExp = require('xregexp');
+const xRegExp = require('xregexp');
 
 /**
  * @name stringQueryBuilder
@@ -8,8 +8,8 @@ const XRegExp = require('xregexp');
  * @return a mongo regex query
  */
 let stringQueryBuilder = function (target) {
-	let t2 = target.replace(/[\\(\\)\\-\\_\\+\\=\\/\\.]/g, '\\$&');
-	return {$regex: new RegExp('^' + t2, 'i')};
+    let t2 = target.replace(/[\\(\\)\\-\\_\\+\\=\\/\\.]/g, '\\$&');
+    return {$regex: new RegExp('^' + t2, 'i')};
 };
 
 /**
@@ -20,20 +20,20 @@ let stringQueryBuilder = function (target) {
  * @return {array} ors
  */
 let addressQueryBuilder = function (target) {
-	// Tokenize the input as mush as possible
-	let totalSplit = target.split(/[\s,]+/);
-	let ors = [];
-	for (let index in totalSplit) {
-		ors.push({$or: [
-			{'address.line': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
-			{'address.city': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
-			{'address.district': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
-			{'address.state': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
-			{'address.postalCode': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
-			{'address.country': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}}
-		]});
-	}
-	return ors;
+    // Tokenize the input as mush as possible
+    let totalSplit = target.split(/[\s,]+/);
+    let ors = [];
+    for (let index in totalSplit) {
+        ors.push({$or: [
+                {'address.line': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
+                {'address.city': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
+                {'address.district': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
+                {'address.state': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
+                {'address.postalCode': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}},
+                {'address.country': {$regex: new RegExp(`${totalSplit[index]}`, 'i')}}
+            ]});
+    }
+    return ors;
 };
 
 /**
@@ -44,19 +44,19 @@ let addressQueryBuilder = function (target) {
  * @return {array} ors
  */
 let nameQueryBuilder = function (target) {
-let split = target.split(/[\s.,]+/);
-let ors = [];
+    let split = target.split(/[\s.,]+/);
+    let ors = [];
 
-for (let i in split) {
-	ors.push( {$or: [
-	{'name.text': {$regex: new RegExp(`${split[i]}`, 'i')}},
-	{'name.family': {$regex: new RegExp(`${split[i]}`, 'i')}},
-	{'name.given': {$regex: new RegExp(`${split[i]}`, 'i')}},
-	{'name.suffix': {$regex: new RegExp(`${split[i]}`, 'i')}},
-	{'name.prefix': {$regex: new RegExp(`${split[i]}`, 'i')}}
-	]});
-}
-return ors;
+    for (let i in split) {
+        ors.push( {$or: [
+                {'name.text': {$regex: new RegExp(`${split[i]}`, 'i')}},
+                {'name.family': {$regex: new RegExp(`${split[i]}`, 'i')}},
+                {'name.given': {$regex: new RegExp(`${split[i]}`, 'i')}},
+                {'name.suffix': {$regex: new RegExp(`${split[i]}`, 'i')}},
+                {'name.prefix': {$regex: new RegExp(`${split[i]}`, 'i')}}
+            ]});
+    }
+    return ors;
 };
 
 /**
@@ -68,36 +68,36 @@ return ors;
  * @return {JSON} queryBuilder
  * Using to assign a single variable:
  *      let queryBuilder = tokenQueryBuilder(identifier, 'value', 'identifier');
-		 for (let i in queryBuilder) {
+ for (let i in queryBuilder) {
 			 query[i] = queryBuilder[i];
 		}
-* Use in an or query
-*      query.$or = [tokenQueryBuilder(identifier, 'value', 'identifier'), tokenQueryBuilder(type, 'code', 'type.coding')];
-*/
+ * Use in an or query
+ *      query.$or = [tokenQueryBuilder(identifier, 'value', 'identifier'), tokenQueryBuilder(type, 'code', 'type.coding')];
+ */
 let tokenQueryBuilder = function (target, type, field, required) {
-	let queryBuilder = {};
-	let system = '';
-	let value = '';
+    let queryBuilder = {};
+    let system = '';
+    let value = '';
 
-	if (target.includes('|')) {
-		[ system, value ] = target.split('|');
+    if (target.includes('|')) {
+        [ system, value ] = target.split('|');
 
-		if (required) {
-			system = required;
-		}
-	}
-	else {
-		value = target;
-	}
+        if (required) {
+            system = required;
+        }
+    }
+    else {
+        value = target;
+    }
 
-	if (system) {
-		queryBuilder[`${field}.system`] = system;
-	}
-	if (value) {
-		queryBuilder[`${field}.${type}`] = value;
-	}
+    if (system) {
+        queryBuilder[`${field}.system`] = system;
+    }
+    if (value) {
+        queryBuilder[`${field}.${type}`] = value;
+    }
 
-	return queryBuilder;
+    return queryBuilder;
 };
 
 /**
@@ -107,25 +107,25 @@ let tokenQueryBuilder = function (target, type, field, required) {
  * @return {JSON} queryBuilder
  */
 let referenceQueryBuilder = function (target, field) {
-	const regex = /http(.*)?\/(\w+\/.+)$/;
-	const match = target.match(regex);
-	let queryBuilder = {};
+    const regex = /http(.*)?\/(\w+\/.+)$/;
+    const match = target.match(regex);
+    let queryBuilder = {};
 
-	// Check if target is a url
-	if (match) {
-		queryBuilder[field] = match[2];
-	}
-	// target = type/id
-	else if (target.includes('/')) {
-		let [type, id] = target.split('/');
-		queryBuilder[field] = `${type}/${id}`;
-	}
-	// target = id The type may be there so we need to check the end of the field for the id
-	else {
-		queryBuilder[field] = {$regex: new RegExp(`${target}$`)};
-	}
+    // Check if target is a url
+    if (match) {
+        queryBuilder[field] = match[2];
+    }
+    // target = type/id
+    else if (target.includes('/')) {
+        let [type, id] = target.split('/');
+        queryBuilder[field] = `${type}/${id}`;
+    }
+    // target = id The type may be there so we need to check the end of the field for the id
+    else {
+        queryBuilder[field] = {$regex: new RegExp(`${target}$`)};
+    }
 
-	return queryBuilder;
+    return queryBuilder;
 };
 
 /**
@@ -136,47 +136,47 @@ let referenceQueryBuilder = function (target, field) {
  * @returns {JSON} a mongo query
  */
 let numberQueryBuilder = function (target) {
-	let prefix = '';
-	let number = '';
-	let sigfigs = '';
+    let prefix = '';
+    let number = '';
+    let sigfigs = '';
 
-	// Check if there is a prefix
-	if (isNaN(target)) {
-		prefix = target.substring(0, 2);
-		number = parseFloat(target.substring(2));
-		sigfigs = target.substring(2);
-	}
-	else {
-		number = parseFloat(target);
-		sigfigs = target;
-	}
+    // Check if there is a prefix
+    if (isNaN(target)) {
+        prefix = target.substring(0, 2);
+        number = parseFloat(target.substring(2));
+        sigfigs = target.substring(2);
+    }
+    else {
+        number = parseFloat(target);
+        sigfigs = target;
+    }
 
-	// Check for prefix and return the appropriate query
-	// Missing eq(default), sa, eb, and ap prefixes
-	switch (prefix) {
-		case 'lt':
-			return {$lt: number};
-		case 'le' :
-			return {$lte: number};
-		case 'gt':
-			return {$gt: number};
-		case 'ge':
-			return {$gte: number};
-		case 'ne':
-			return {$ne: number};
-	}
+    // Check for prefix and return the appropriate query
+    // Missing eq(default), sa, eb, and ap prefixes
+    switch (prefix) {
+        case 'lt':
+            return {$lt: number};
+        case 'le' :
+            return {$lte: number};
+        case 'gt':
+            return {$gt: number};
+        case 'ge':
+            return {$gte: number};
+        case 'ne':
+            return {$ne: number};
+    }
 
-	// Return an approximation query
-	let decimals = sigfigs.split('.')[1];
-	if (decimals) {
-		decimals = decimals.length + 1;
-	}
-	else {
-		decimals = 1;
-	}
-	let aprox = (1 / 10 ** decimals) * 5;
+    // Return an approximation query
+    let decimals = sigfigs.split('.')[1];
+    if (decimals) {
+        decimals = decimals.length + 1;
+    }
+    else {
+        decimals = 1;
+    }
+    let aprox = (1 / 10 ** decimals) * 5;
 
-	return {$gte: number - aprox, $lt: number + aprox};
+    return {$gte: number - aprox, $lt: number + aprox};
 
 };
 
@@ -187,73 +187,47 @@ let numberQueryBuilder = function (target) {
  * @param field path to specific field in the resource
  */
 let quantityQueryBuilder = function (target, field) {
-let qB = {};
+    let qB = {};
 //split by the two pipes
-let [num, system, code] = target.split('|');
+    let [num, system, code] = target.split('|');
 
-if (system) {
-	qB[`${field}.system`] = system;
-}
-if (code) {
-	qB[`${field}.code`] = code;
-}
+    if (system) {
+        qB[`${field}.system`] = system;
+    }
+    if (code) {
+        qB[`${field}.code`] = code;
+    }
 
-if (isNaN(num)) { //with prefixes
-	let prefix = num.substring(0, 2);
-	num = Number(num.substring(2));
+    if (isNaN(num)) { //with prefixes
+        let prefix = num.substring(0, 2);
+        num = Number(num.substring(2));
 
-	// Missing eq(default), sa, eb, and ap prefixes
-	switch (prefix) {
-		case 'lt':
-			qB[`${field}.value`] = {$lt: num};
-			break;
-		case 'le' :
-			qB[`${field}.value`] = {$lte: num};
-			break;
-		case 'gt':
-			qB[`${field}.value`] = {$gt: num};
-			break;
-		case 'ge':
-			qB[`${field}.value`] = {$gte: num};
-			break;
-		case 'ne':
-			qB[`${field}.value`] = {$ne: num};
-			break;
-	}
-}
-else { //no prefixes
-	qB[`${field}.value`] = Number(num);
-}
+        // Missing eq(default), sa, eb, and ap prefixes
+        switch (prefix) {
+            case 'lt':
+                qB[`${field}.value`] = {$lt: num};
+                break;
+            case 'le' :
+                qB[`${field}.value`] = {$lte: num};
+                break;
+            case 'gt':
+                qB[`${field}.value`] = {$gt: num};
+                break;
+            case 'ge':
+                qB[`${field}.value`] = {$gte: num};
+                break;
+            case 'ne':
+                qB[`${field}.value`] = {$ne: num};
+                break;
+        }
+    }
+    else { //no prefixes
+        qB[`${field}.value`] = Number(num);
+    }
 
-return qB;
+    return qB;
 };
 
-//for modular arithmetic because % is just for remainder -> JS is a cruel joke
-function mod(n, m) {
-return ((n % m) + m) % m;
-}
-
-//gives the number of days from year 0, used for adding or subtracting days from a date
-let getDayNum = function (year, month, day) {
-month = mod((month + 9), 12);
-year = year - Math.floor(month / 10);
-return (365 * year + Math.floor(year / 4) - Math.floor(year / 100) + Math.floor(year / 400) + Math.floor((month * 306 + 5) / 10) + ( day - 1 ));
-};
-
-//returns a date given the number of days from year 0;
-let getDateFromNum = function (days) {
-let year = Math.floor((10000 * days + 14780) / 3652425);
-let day2 = days - (365 * year + Math.floor(year / 4) - Math.floor(year / 100) + Math.floor(year / 400));
-if (day2 < 0) {
-	year = year - 1;
-	day2 = days - (365 * year + Math.floor(year / 4) - Math.floor(year / 100) + Math.floor(year / 400));
-}
-let m1 = Math.floor((100 * day2 + 52) / 3060);
-let month = mod((m1 + 2), 12) + 1;
-year = year + Math.floor((m1 + 2) / 12);
-let rDay = day2 - Math.floor((m1 * 306 + 5) / 10) + 1;
-return year.toString() + '-' + ('0' + month).slice(-2) + '-' + ('0' + rDay).slice(-2);
-};
 
 /**
  * Parses out the attributes of the supplied date and builds a mongo query based on what was supplied.
@@ -291,125 +265,125 @@ return year.toString() + '-' + ('0' + month).slice(-2) + '-' + ('0' + rDay).slic
  */
 let dateQueryBuilder = function (date) {
     // If the date is a moment object, turn it into an ISO Date String
-	let formattedDate = date;
-	if (moment.isMoment(formattedDate)) {
+    let formattedDate = date;
+    if (moment.isMoment(formattedDate)) {
         formattedDate = formattedDate.toISOString();
-	}
+    }
 
-	// Use a regular expression to parse out the attributes of the incoming query.
-	const dateRegex = XRegExp(`
+    // Use a regular expression to parse out the attributes of the incoming query.
+    const dateRegex = xRegExp(`
         (?<prefix>  [A-Za-z]{2} )?     # prefix
         (?<year>    [0-9]{4} )    -?   # year (required)
         (?<month>   [0-9]{2} )?   -?   # month
         (?<day>     [0-9]{2} )?   T?   # day
-        (?<hour>    [0-9]{2} )?   \:?  # hour
-        (?<minute>  [0-9]{2} )?   \:?  # minute
+        (?<hour>    [0-9]{2} )?   :?   # hour
+        (?<minute>  [0-9]{2} )?   :?   # minute
         (?<second>  [0-9]{2} )?        # second
         (?<timezone>   .*)?            # timezone
         `, 'x');
-	let parsedDatetime = XRegExp.exec(formattedDate, dateRegex);
+    let parsedDatetime = xRegExp.exec(formattedDate, dateRegex);
 
     // Map of the date attributes and their properties in order of decreasing granularity
-	// Default values are provided here and used if values aren't provided in the query
-	// Interval Scale is used to determine the range of 'equals' queries based on the
-	// level of datetime granularity provided in the query.
-	const dateAttributes = new Map([
+    // Default values are provided here and used if values aren't provided in the query
+    // Interval Scale is used to determine the range of 'equals' queries based on the
+    // level of datetime granularity provided in the query.
+    const dateAttributes = new Map([
         ['second', {value: '00', intervalScale: 'minutes'}],
         ['minute', {value: '00', intervalScale: 'hours'}],
         ['hour', {value: '00', intervalScale: 'days'}],
         ['day', {value: '01', intervalScale: 'months'}],
         ['month', {value: '01', intervalScale: 'years'}],
         ['year', {value: null, intervalScale: null}]
-	]);
+    ]);
 
-	// Iterate through each of date attributes in order of decreasing granularity
+    // Iterate through each of date attributes in order of decreasing granularity
     // For each date attribute...
-	let supplied_date_attributes = [];
+    let supplied_date_attributes = [];
     let intervalScale = null;
-	for (let [attribute, properties] of dateAttributes.entries()){
-		// If we were able to parse the attribute out of the supplied date...
+    for (let [attribute, properties] of dateAttributes.entries()){
+        // If we were able to parse the attribute out of the supplied date...
         if (parsedDatetime[attribute]) {
             // Overwrite the attribute's default value
-        	properties.value = parsedDatetime[attribute];
-        	// Push it into the supplied attributes array to record that this attribute was supplied
+            properties.value = parsedDatetime[attribute];
+            // Push it into the supplied attributes array to record that this attribute was supplied
             supplied_date_attributes.push(properties.value);
         } else {
-        	// Else, overwrite the current intervalScale with this attribute's interval scale. Because the loop
-			// is in order of decreasing granularity, the final interval scale will be the least granular one.
+            // Else, overwrite the current intervalScale with this attribute's interval scale. Because the loop
+            // is in order of decreasing granularity, the final interval scale will be the least granular one.
             intervalScale = properties.intervalScale;
-		}
-	}
-	// Reverse the order of the supplied date attributes so that they're in the order a date is normally written.
-	supplied_date_attributes.reverse();
+        }
+    }
+    // Reverse the order of the supplied date attributes so that they're in the order a date is normally written.
+    supplied_date_attributes.reverse();
 
-	// Create a moment object of the target date (the date supplied as input) using the date attribute values
-	let targetDate = moment(new Date(
-		[dateAttributes.get('year').value, dateAttributes.get('month').value, dateAttributes.get('day').value].join('-')
-		+ 'T'
-		+ [dateAttributes.get('hour').value, dateAttributes.get('minute').value, dateAttributes.get('second').value].join(':')
-	));
+    // Create a moment object of the target date (the date supplied as input) using the date attribute values
+    let targetDate = moment(new Date(
+        [dateAttributes.get('year').value, dateAttributes.get('month').value, dateAttributes.get('day').value].join('-')
+        + 'T'
+        + [dateAttributes.get('hour').value, dateAttributes.get('minute').value, dateAttributes.get('second').value].join(':')
+    ));
 
-	// An object mapping the possible query prefixes to the modifiers used to build an appropriate mongo query
+    // An object mapping the possible query prefixes to the modifiers used to build an appropriate mongo query
     const queryModifiers = {
-        'eq': '',        // equal
-		undefined: '',   // equal (implied)
-		null: '',        // equal (implied)
-		'ne': 'ne',      // not equal
-		'gt': '$gt',     // greater than
-		'ge': '$gte',    // greater than or equal to
-		'lt': '$lt',     // less than
-		'le': '$lte',    // less than or equal to
-		'sa': '$gt',     // starts after (equivalent to 'greater than' for dates)
-		'eb': '$lt',     // ends before (equivalent to 'less than' for dates)
-		'ap': 'ap'       // approximately
-	};
+        'eq': '',			// equal
+        undefined: '',		// equal (implied)
+        null: '',			// equal (implied)
+        'ne': 'ne',			// not equal
+        'gt': '$gt',		// greater than
+        'ge': '$gte',		// greater than or equal to
+        'lt': '$lt',		// less than
+        'le': '$lte',		// less than or equal to
+        'sa': '$gt',		// starts after (equivalent to 'greater than' for dates)
+        'eb': '$lt',		// ends before (equivalent to 'less than' for dates)
+        'ap': 'ap'			// approximately
+    };
 
     // Retrieve the appropriate query modifier for the supplied prefix
-	let queryModifier = queryModifiers[parsedDatetime.prefix];
+    let queryModifier = queryModifiers[parsedDatetime.prefix];
 
     // Construct mongo queries based on the query modifier
-	let dateQuery;
+    let dateQuery;
     if (queryModifier === '') {
         // Construct a query for 'equal' if the 'eq' prefix was provided or if no prefix was provided
         // If we have an interval scale, query the appropriate range
-		if (intervalScale) {
+        if (intervalScale) {
             let endDate = moment(targetDate).add(1, intervalScale);
             dateQuery = {$gte: targetDate.toISOString(), $lt: endDate.toISOString()};
-		} else {
+        } else {
             // Else, we have an exact datetime, so query it directly
-			dateQuery = targetDate;
-		}
+            dateQuery = targetDate;
+        }
 
     } else if (queryModifier === 'ne') {
         // Construct a query for 'not equal' if the 'ne' prefix was provided
         // TODO - This works, but I'm not sure that it's the best way to do things. The only alternative I could think
-		// TODO - of was to use mongo's $or key, but that would require some refactoring because of key structure.
+        // TODO - of was to use mongo's $or key, but that would require some refactoring because of key structure.
 
-		// Construct a regex that matches ISO date strings that don't match the pattern to whatever level of
-		// granularity is appropriate based on the supplied date. For example, ne2000-01 will match all dates
-		// that aren't in January of 2000.
-		let mongoRegex = '^((?!';
-		for (let i in supplied_date_attributes) {
-			mongoRegex += supplied_date_attributes[i] + '[\\:\\-T]?';
-		}
-		mongoRegex += ').)*$';
-		dateQuery = {$regex: mongoRegex};
+        // Construct a regex that matches ISO date strings that don't match the pattern to whatever level of
+        // granularity is appropriate based on the supplied date. For example, ne2000-01 will match all dates
+        // that aren't in January of 2000.
+        let mongoRegex = '^((?!';
+        for (let i in supplied_date_attributes) {
+            mongoRegex += supplied_date_attributes[i] + '[-:T]?';
+        }
+        mongoRegex += ').)*$';
+        dateQuery = {$regex: mongoRegex};
 
     } else if (['$gt', '$gte', '$lt', '$lte'].includes(queryModifier)) {
-		// Construct a query for the relevant comparison operator (>, =>, <, <=, )
-		dateQuery = {[queryModifier]: targetDate.toISOString()};
+        // Construct a query for the relevant comparison operator (>, =>, <, <=, )
+        dateQuery = {[queryModifier]: targetDate.toISOString()};
 
-	} else if (queryModifier === 'ap') {
+    } else if (queryModifier === 'ap') {
         // Construct a query for 'approximately' if the 'ap' prefix was provided. This will query a date range
-		// +/- rangePadding * the difference between the target datetime and the current datetime
-    	const rangePadding = 0.1; // TODO is this an appropriate name? I couldn't think of a better one.
-    	let currentDateTime = moment();
-    	let difference = moment.duration(currentDateTime.diff(targetDate)).asSeconds() * rangePadding;
-    	let lowerBound = moment(targetDate).subtract(difference, 'seconds');
-    	let upperBound = moment(targetDate).add(difference, 'seconds');
+        // +/- rangePadding * the difference between the target datetime and the current datetime
+        const rangePadding = 0.1; // TODO is this an appropriate name? I couldn't think of a better one.
+        let currentDateTime = moment();
+        let difference = moment.duration(currentDateTime.diff(targetDate)).asSeconds() * rangePadding;
+        let lowerBound = moment(targetDate).subtract(difference, 'seconds');
+        let upperBound = moment(targetDate).add(difference, 'seconds');
         dateQuery = {$gte: lowerBound.toISOString(), $lte: upperBound.toISOString()};
-	}
-	return dateQuery;
+    }
+    return dateQuery;
 };
 
 /**
@@ -420,82 +394,82 @@ let dateQueryBuilder = function (date) {
  * @param field2 contains the path and search type
  */
 let compositeQueryBuilder = function(target, field1, field2) {
-	let composite = [];
-	let temp = {};
-	let [ target1, target2 ] = target.split(/[$,]/);
-	let [ path1, type1 ] = field1.split('|');
-	let [ path2, type2 ] = field2.split('|');
+    let composite = [];
+    let temp = {};
+    let [ target1, target2 ] = target.split(/[$,]/);
+    let [ path1, type1 ] = field1.split('|');
+    let [ path2, type2 ] = field2.split('|');
 
-	// Call the right queryBuilder based on type
-	switch (type1) {
-		case 'string':
-			temp = {};
-			temp[`${path1}`] = stringQueryBuilder(target1);
-			composite.push(temp);
-			break;
-		case 'token':
-			composite.push({$or: [{$and: [tokenQueryBuilder(target1, 'code', path1, '')]},
-		{$and: [tokenQueryBuilder(target1, 'value', path1, '')]}]});
-			break;
-		case 'reference':
-			composite.push(referenceQueryBuilder(target1, path1));
-			break;
-		case 'quantity':
-			composite.push(quantityQueryBuilder(target1, path1));
-			break;
-		case 'number':
-			temp = {};
-			temp[`${path1}`] = numberQueryBuilder(target1);
-			composite.push(temp);
-			break;
-		case 'date':
-			composite.push({$or: [{[path1]: dateQueryBuilder(target1, 'date', '')},
-			{[path1]: dateQueryBuilder(target1, 'dateTime', '')}, {[path1]: dateQueryBuilder(target1, 'instant', '')},
-			{$or: dateQueryBuilder(target1, 'period', path1)}, {$or: dateQueryBuilder(target1, 'timing', path1)}]});
-			break;
-		default:
-			temp = {};
-			temp[`${path1}`] = target1;
-			composite.push(temp);
-	}
-	switch (type2) {
-		case 'string':
-			temp = {};
-			temp[`${path2}`] = stringQueryBuilder(target2);
-			composite.push(temp);
-			break;
-		case 'token':
-			composite.push({$or: [{$and: [tokenQueryBuilder(target2, 'code', path2, '')]},
-			{$and: [tokenQueryBuilder(target2, 'value', path2, '')]}]});
-			break;
-		case 'reference':
-			composite.push(referenceQueryBuilder(target2, path2));
-			break;
-		case 'quantity':
-			composite.push(quantityQueryBuilder(target2, path2));
-			break;
-		case 'number':
-			temp = {};
-			temp[`${path2}`] = composite.push(numberQueryBuilder(target2));
-			composite.push(temp);
-			break;
-		case 'date':
-			composite.push({$or: [{[path2]: dateQueryBuilder(target2, 'date', '')},
-			{[path2]: dateQueryBuilder(target2, 'dateTime', '')}, {[path2]: dateQueryBuilder(target2, 'instant', '')},
-			{$or: dateQueryBuilder(target2, 'period', path2)}, {$or: dateQueryBuilder(target2, 'timing', path2)}]});
-			break;
-		default:
-			temp = {};
-			temp[`${path2}`] = target2;
-			composite.push(temp);
-	}
+    // Call the right queryBuilder based on type
+    switch (type1) {
+        case 'string':
+            temp = {};
+            temp[`${path1}`] = stringQueryBuilder(target1);
+            composite.push(temp);
+            break;
+        case 'token':
+            composite.push({$or: [{$and: [tokenQueryBuilder(target1, 'code', path1, '')]},
+                    {$and: [tokenQueryBuilder(target1, 'value', path1, '')]}]});
+            break;
+        case 'reference':
+            composite.push(referenceQueryBuilder(target1, path1));
+            break;
+        case 'quantity':
+            composite.push(quantityQueryBuilder(target1, path1));
+            break;
+        case 'number':
+            temp = {};
+            temp[`${path1}`] = numberQueryBuilder(target1);
+            composite.push(temp);
+            break;
+        case 'date':
+            composite.push({$or: [{[path1]: dateQueryBuilder(target1, 'date', '')},
+                    {[path1]: dateQueryBuilder(target1, 'dateTime', '')}, {[path1]: dateQueryBuilder(target1, 'instant', '')},
+                    {$or: dateQueryBuilder(target1, 'period', path1)}, {$or: dateQueryBuilder(target1, 'timing', path1)}]});
+            break;
+        default:
+            temp = {};
+            temp[`${path1}`] = target1;
+            composite.push(temp);
+    }
+    switch (type2) {
+        case 'string':
+            temp = {};
+            temp[`${path2}`] = stringQueryBuilder(target2);
+            composite.push(temp);
+            break;
+        case 'token':
+            composite.push({$or: [{$and: [tokenQueryBuilder(target2, 'code', path2, '')]},
+                    {$and: [tokenQueryBuilder(target2, 'value', path2, '')]}]});
+            break;
+        case 'reference':
+            composite.push(referenceQueryBuilder(target2, path2));
+            break;
+        case 'quantity':
+            composite.push(quantityQueryBuilder(target2, path2));
+            break;
+        case 'number':
+            temp = {};
+            temp[`${path2}`] = composite.push(numberQueryBuilder(target2));
+            composite.push(temp);
+            break;
+        case 'date':
+            composite.push({$or: [{[path2]: dateQueryBuilder(target2, 'date', '')},
+                    {[path2]: dateQueryBuilder(target2, 'dateTime', '')}, {[path2]: dateQueryBuilder(target2, 'instant', '')},
+                    {$or: dateQueryBuilder(target2, 'period', path2)}, {$or: dateQueryBuilder(target2, 'timing', path2)}]});
+            break;
+        default:
+            temp = {};
+            temp[`${path2}`] = target2;
+            composite.push(temp);
+    }
 
-	if (target.includes('$')) {
-		return {$and: composite};
-	}
-	else {
-		return {$or: composite};
-	}
+    if (target.includes('$')) {
+        return {$and: composite};
+    }
+    else {
+        return {$or: composite};
+    }
 
 };
 
@@ -503,13 +477,13 @@ let compositeQueryBuilder = function(target, field1, field2) {
  * @todo build out all prefix functionality for number and quantity and add date queries
  */
 module.exports = {
-	stringQueryBuilder,
-	tokenQueryBuilder,
-	referenceQueryBuilder,
-	addressQueryBuilder,
-	nameQueryBuilder,
-	numberQueryBuilder,
-	quantityQueryBuilder,
-	compositeQueryBuilder,
-	dateQueryBuilder
+    stringQueryBuilder,
+    tokenQueryBuilder,
+    referenceQueryBuilder,
+    addressQueryBuilder,
+    nameQueryBuilder,
+    numberQueryBuilder,
+    quantityQueryBuilder,
+    compositeQueryBuilder,
+    dateQueryBuilder
 };

--- a/src/utils/querybuilder.util.test.js
+++ b/src/utils/querybuilder.util.test.js
@@ -1,0 +1,504 @@
+const moment = require('moment-timezone');
+const { dateQueryBuilder } = require('./querybuilder.util');
+
+
+describe('Query Builder Tests', () => {
+    describe('Date Query Builder Tests', () => {
+        test('Should return the ISO String if given a moment object', () => {
+            const testMoment = moment('2018-10-31T17:49:29.000Z');
+            const expectedResult = '2018-10-31T17:49:29.000Z';
+            let observedResult = dateQueryBuilder(testMoment);
+            expect(observedResult).toEqual(expectedResult);
+        });
+        describe('No Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return the ISO String if the given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = '2018-10-31T17:49:29.000Z';
+                const expectedResult = '2018-10-31T17:49:29.000Z';
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return the ISO String if given a partial ISO string of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = '2018-10-31T17:49:29';
+                const expectedResult = '2018-10-31T17:49:29.000Z';
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 minute range if given a partial ISO string of format \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = '2018-10-31T17:49';
+                const expectedResult = {'$gte': '2018-10-31T17:49:00.000Z', '$lte': '2018-10-31T17:49:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this next situation from ever occurring.
+            // TODO - as hours without minutes are not allowed
+            test('Should return a 1 hour range if given a partial ISO string of format \'yyyy-mm-ddThh\'', () => {
+                const testString = '2018-10-31T17';
+                const expectedResult = {'$gte': '2018-10-31T17:00:00.000Z', '$lte': '2018-10-31T17:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 day range if given a partial ISO string of format \'yyyy-mm-dd\'', () => {
+                const testString = '2018-10-31';
+                const expectedResult = {'$gte': '2018-10-31T00:00:00.000Z', '$lte': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 month range if given a partial ISO string of format \'yyyy-mm\'', () => {
+                const testString = '2018-10';
+                const expectedResult = {'$gte': '2018-10-01T00:00:00.000Z', '$lte': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 year range if given a partial ISO string of format \'yyyy\'', () => {
+                const testString = '2018';
+                const expectedResult = {'$gte': '2018-01-01T00:00:00.000Z', '$lte': '2018-12-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('eq Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return the ISO String if the given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'eq2018-10-31T17:49:29.000Z';
+                const expectedResult = '2018-10-31T17:49:29.000Z';
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return the ISO String if given a partial ISO string of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'eq2018-10-31T17:49:29';
+                const expectedResult = '2018-10-31T17:49:29.000Z';
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 minute range if given a partial ISO string of format \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'eq2018-10-31T17:49';
+                const expectedResult = {'$gte': '2018-10-31T17:49:00.000Z', '$lte': '2018-10-31T17:49:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return a 1 hour range if given a partial ISO string of format \'yyyy-mm-ddThh\'', () => {
+                const testString = 'eq2018-10-31T17';
+                const expectedResult = {'$gte': '2018-10-31T17:00:00.000Z', '$lte': '2018-10-31T17:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 day range if given a partial ISO string of format \'yyyy-mm-dd\'', () => {
+                const testString = 'eq2018-10-31';
+                const expectedResult = {'$gte': '2018-10-31T00:00:00.000Z', '$lte': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 month range if given a partial ISO string of format \'yyyy-mm\'', () => {
+                const testString = 'eq2018-10';
+                const expectedResult = {'$gte': '2018-10-01T00:00:00.000Z', '$lte': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a 1 year range if given a partial ISO string of format \'yyyy\'', () => {
+                const testString = 'eq2018';
+                const expectedResult = {'$gte': '2018-01-01T00:00:00.000Z', '$lte': '2018-12-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('ne Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return a regex that fully excludes a given full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'ne2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?31[-:T]?17[-:T]?49[-:T]?29[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a regex that fully excludes a given partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'ne2018-10-31T17:49:29';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?31[-:T]?17[-:T]?49[-:T]?29[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a regex that fully excludes the specified minute in given partial ISO String of format \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'ne2018-10-31T17:49';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?31[-:T]?17[-:T]?49[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return a regex that fully excludes the specified hour in given partial ISO String of format \'yyyy-mm-ddThh\'', () => {
+                const testString = 'ne2018-10-31T17';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?31[-:T]?17[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a regex that fully excludes the specified day in given partial ISO String of format \'yyyy-mm-dd\'', () => {
+                const testString = 'ne2018-10-31';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?31[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a regex that fully excludes the specified month in given partial ISO String of format \'yyyy-mm\'', () => {
+                const testString = 'ne2018-10';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?10[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return a regex that fully excludes the specified year in given partial ISO String of format \'yyyy\'', () => {
+                const testString = 'ne2018';
+                const expectedResult = {'$regex': '^((?!2018[-:T]?).)*$'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('gt Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $gt ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'gt2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$gt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'gt2018-10-31T17:49:29';
+                const expectedResult = {'$gt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'gt2018-10-31T17:49';
+                const expectedResult = {'$gt': '2018-10-31T17:49:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $gt end of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'gt2018-10-31T17';
+                const expectedResult = {'$gt': '2018-10-31T17:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'gt2018-10-31';
+                const expectedResult = {'$gt': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'gt2018-10';
+                const expectedResult = {'$gt': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'gt2018';
+                const expectedResult = {'$gt': '2018-12-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('ge Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $gte ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'ge2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$gte': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gte ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'ge2018-10-31T17:49:29';
+                const expectedResult = {'$gte': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gte start of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'ge2018-10-31T17:49';
+                const expectedResult = {'$gte': '2018-10-31T17:49:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $gte start of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'ge2018-10-31T17';
+                const expectedResult = {'$gte': '2018-10-31T17:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gte start of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'ge2018-10-31';
+                const expectedResult = {'$gte': '2018-10-31T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gte start of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'ge2018-10';
+                const expectedResult = {'$gte': '2018-10-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gte start of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'ge2018';
+                const expectedResult = {'$gte': '2018-01-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('lt Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $lt ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'lt2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$lt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'lt2018-10-31T17:49:29';
+                const expectedResult = {'$lt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'lt2018-10-31T17:49';
+                const expectedResult = {'$lt': '2018-10-31T17:49:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $lt start of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'lt2018-10-31T17';
+                const expectedResult = {'$lt': '2018-10-31T17:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'lt2018-10-31';
+                const expectedResult = {'$lt': '2018-10-31T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'lt2018-10';
+                const expectedResult = {'$lt': '2018-10-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'lt2018';
+                const expectedResult = {'$lt': '2018-01-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('le Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $lte ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'le2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$lte': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lte ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'le2018-10-31T17:49:29';
+                const expectedResult = {'$lte': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lte start of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'le2018-10-31T17:49';
+                const expectedResult = {'$lte': '2018-10-31T17:49:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $lte start of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'le2018-10-31T17';
+                const expectedResult = {'$lte': '2018-10-31T17:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lte start of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'le2018-10-31';
+                const expectedResult = {'$lte': '2018-10-31T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lte start of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'le2018-10';
+                const expectedResult = {'$lte': '2018-10-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lte start of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'le2018';
+                const expectedResult = {'$lte': '2018-01-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('sa Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $gt ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'sa2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$gt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'sa2018-10-31T17:49:29';
+                const expectedResult = {'$gt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'sa2018-10-31T17:49';
+                const expectedResult = {'$gt': '2018-10-31T17:49:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $gt end of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'sa2018-10-31T17';
+                const expectedResult = {'$gt': '2018-10-31T17:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'sa2018-10-31';
+                const expectedResult = {'$gt': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'sa2018-10';
+                const expectedResult = {'$gt': '2018-10-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $gt end of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'sa2018';
+                const expectedResult = {'$gt': '2018-12-31T23:59:59.999Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('eb Prefix Tests', () => {
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as providing milliseconds is not allowed.
+            test('Should return $lt ISO String if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'eb2018-10-31T17:49:29.000Z';
+                const expectedResult = {'$lt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt ISO String if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'eb2018-10-31T17:49:29';
+                const expectedResult = {'$lt': '2018-10-31T17:49:29.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of minute if given a partial ISO String \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'eb2018-10-31T17:49';
+                const expectedResult = {'$lt': '2018-10-31T17:49:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            // TODO - Note that the sanitizer should stop this situation from ever occurring.
+            // TODO - as hours without minutes are not allowed.
+            test('Should return $lt start of hour if given a partial ISO String \'yyyy-mm-ddThh\'', () => {
+                const testString = 'eb2018-10-31T17';
+                const expectedResult = {'$lt': '2018-10-31T17:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of day if given a partial ISO String \'yyyy-mm-dd\'', () => {
+                const testString = 'eb2018-10-31';
+                const expectedResult = {'$lt': '2018-10-31T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of month if given a partial ISO String \'yyyy-mm\'', () => {
+                const testString = 'eb2018-10';
+                const expectedResult = {'$lt': '2018-10-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return $lt start of year if given a partial ISO String \'yyyy\'', () => {
+                const testString = 'eb2018';
+                const expectedResult = {'$lt': '2018-01-01T00:00:00.000Z'};
+                let observedResult = dateQueryBuilder(testString);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+        describe('ap Prefix Tests', () => {
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the target date if given a full ISO String \'yyyy-mm-ddThh:mm:ss.###Z\'', () => {
+                const testString = 'ap2000-10-31T17:49:29.000Z';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1999-01-13T05:57:45.827Z', '$lte': '2002-08-20T05:41:12.173Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the target date if given a partial ISO String of format \'yyyy-mm-ddThh:mm:ss\'', () => {
+                const testString = 'ap2000-10-31T17:49:29';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1999-01-13T05:57:45.827Z', '$lte': '2002-08-20T05:41:12.173Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the start of the specified minute if given a partial ISO String of format \'yyyy-mm-ddThh:mm\'', () => {
+                const testString = 'ap2000-10-31T17:49';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1999-01-13T05:57:13.927Z', '$lte': '2002-08-20T05:40:46.073Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the start of the specified hour if given a partial ISO String of format \'yyyy-mm-ddThh\'', () => {
+                const testString = 'ap2000-10-31T17';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1999-01-13T05:03:19.927Z', '$lte': '2002-08-20T04:56:40.073Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the start of the specified day if given a partial ISO String of format \'yyyy-mm-dd\'', () => {
+                const testString = 'ap2000-10-31';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1999-01-12T10:21:19.927Z', '$lte': '2002-08-19T13:38:40.073Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the start of the specified month if given a partial ISO String of format \'yyyy-mm\'', () => {
+                const testString = 'ap2000-10';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1998-12-10T10:21:19.927Z', '$lte': '2002-07-23T13:38:40.073Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+            test('Should return range with upper lower bounds equal to the target date +/- 0.1 * the amount of time ' +
+                'between now and the start of the specified year if given a partial ISO String of format \'yyyy\'', () => {
+                const testString = 'ap2000';
+                const currentDateTimeOverride = '2018-11-01T16:26:40.730Z';
+                const expectedResult = {'$gte': '1998-02-12T00:45:19.927Z', '$lte': '2001-11-18T23:14:40.073Z'};
+                let observedResult = dateQueryBuilder(testString, currentDateTimeOverride);
+                expect(observedResult).toEqual(expectedResult);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Temporary fix for the issue with the date parameter. The date query builder functions expect a string and try to call `match` on a string. This resolves that issue by formatting the date first into a format that the query builder is expecting.

Further cleanup on this function will come later. The logic in the regex is a little convoluted and unnecessary. It parses the date string into various components. Moment provides a much easier method for obtaining this. This should also include unit tests in the future as well.

Related to issue #24 