### PR TITLE
Docker build did not work because apt-get sources could not be found.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:8.9.4
 
+# Enable apt-get to run from the new sources.
+RUN printf "deb http://archive.debian.org/debian/ \
+    jessie main\ndeb-src http://archive.debian.org/debian/ \
+    jessie main\ndeb http://security.debian.org \
+    jessie/updates main\ndeb-src http://security.debian.org \
+    jessie/updates main" > /etc/apt/sources.list
+
 # Update everything on the box
 RUN apt-get -y update
 RUN apt-get clean


### PR DESCRIPTION
Solved the below issue (logs attached) during Docker build (as initiated by `docker-compose up`).
Added required sources for `apt-get`.

```
Sending build context to Docker daemon   22.1MB
Step 1/8 : FROM node:8.9.4
 ---> 672002a50a0b
Step 2/8 : RUN apt-get -y update
 ---> Running in 7ed3376e2b03
Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [7340 B]
Get:3 http://deb.debian.org jessie Release.gpg [2420 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [842 kB]
Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]
Fetched 10.1 MB in 6s (1688 kB/s)
W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

E: Some index files failed to download. They have been ignored, or old ones used instead.
```