### PR TITLE
fixing query construction for patient search after R4 changes

### DIFF
--- a/src/services/patient/patient.service.js
+++ b/src/services/patient/patient.service.js
@@ -419,6 +419,8 @@ module.exports.search = (args) => new Promise((resolve, reject) => {
 		query = buildStu3SearchQuery(args);
 	} else if (base_version === VERSIONS['1_0_2']) {
 		query = buildDstu2SearchQuery(args);
+	} else if (base_version === VERSIONS['4_0_0']){
+		query = buildStu3SearchQuery(args);
 	}
 
 	// Grab an instance of our DB and collection
@@ -659,6 +661,8 @@ module.exports.history = (args, context) => new Promise((resolve, reject) => {
 		query = buildStu3SearchQuery(args);
 	} else if (base_version === VERSIONS['1_0_2']) {
 		query = buildDstu2SearchQuery(args);
+	} else if (base_version === VERSIONS['4_0_0']){
+		query = buildStu3SearchQuery(args);
 	}
 
 	// Grab an instance of our DB and collection
@@ -693,6 +697,8 @@ module.exports.historyById = (args, context) => new Promise((resolve, reject) =>
 		query = buildStu3SearchQuery(args);
 	} else if (base_version === VERSIONS['1_0_2']) {
 		query = buildDstu2SearchQuery(args);
+	} else if (base_version === VERSIONS['4_0_0']){
+		query = buildStu3SearchQuery(args);
 	}
 
 	query.id = `${id}`;


### PR DESCRIPTION
There are a few if/else blocks in the patient.service.js file that check against the base version before building a query for searching. If the base version is 4_0_0, it does not get caught by any else block, and so does not build a query. This is a fix for that which I believe is still in line with R4 spec, because from what I can tell from the spec, anything that isn't specifically noted in the new R4 changes reverts back to STU3. Feel free to modify this or change in your preferred way, but thought I would at least bring it to your attention.