### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.13.0
+FROM node:10.19.0
 
 # Enable apt-get to run from the new sources.
 RUN printf "deb http://archive.debian.org/debian/ \


### PR DESCRIPTION
Fix docker-compose up error

After run 
```bash
docker-compose up
```

It is showing error:
```bash
[3/5] Fetching packages...
error got@11.4.0: The engine "node" is incompatible with this module. Expected version ">=10.19.0". Got "10.13.0"
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
ERROR: Service 'fhir' failed to build: The command '/bin/sh -c yarn install' returned a non-zero code: 1
```

Solution: update node js version